### PR TITLE
Use a unique constraint to prevent duplicate cron jobs

### DIFF
--- a/resources/cachemanager.hbm.xml
+++ b/resources/cachemanager.hbm.xml
@@ -28,8 +28,14 @@
       <one-to-many class="pt.webdetails.cda.cache.CachedParam"/>
     </list>
     <subclass discriminator-value="CACHED" name="pt.webdetails.cda.cache.CachedQuery">
-      <property name="userName" type="string">
-        <column name="uname"/>
+      <property name="cdaFile" not-null="true" type="string" unique-key="single_cron" insert="false" update="false">
+         <column length="254" name="cdaFile" not-null="true"/>
+      </property>
+      <property name="dataAccessId" not-null="true" type="string" unique-key="single_cron" insert="false" update="false">
+        <column length="254" name="dataAccessId" not-null="true"/>
+      </property>
+      <property name="userName" type="string" unique-key="single_cron">
+        <column length="50" name="uname"/>
       </property>
       <property name="lastExecuted" type="timestamp">
         <column name="lastExecuted"/>
@@ -37,8 +43,11 @@
       <property name="nextExecution" type="timestamp">
         <column name="nextExecution"/>
       </property>
-      <property name="cronString" not-null="true" type="string">
-        <column length="254" name="cronString" not-null="true"/>
+      <property name="cronString" not-null="true" type="string" unique-key="single_cron">
+        <column length="50" name="cronString" not-null="true"/>
+      </property>
+      <property name="parametersAsString" type="string" unique-key="single_cron">
+        <column length="254" name="params" />
       </property>
       <property name="success" type="boolean">
         <column name="success"/>

--- a/src/pt/webdetails/cda/cache/CacheScheduleManager.java
+++ b/src/pt/webdetails/cda/cache/CacheScheduleManager.java
@@ -16,6 +16,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.hibernate.Session;
+import org.hibernate.exception.ConstraintViolationException;
 import org.pentaho.platform.api.engine.IParameterProvider;
 import org.pentaho.platform.api.engine.IPluginResourceLoader;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
@@ -252,10 +253,20 @@ public class CacheScheduleManager
 
       Session s = getHibernateSession();
       s.beginTransaction();
-      s.save(q);
-      s.flush();
-      s.getTransaction().commit();
-      s.close();
+      try
+      {
+         s.save(q);
+         s.flush();
+         s.getTransaction().commit();
+      }
+      catch (ConstraintViolationException e)
+      {
+         logger.debug("Duplicate cron job suppressed");
+      }
+      finally
+      {
+         s.close();
+      }
 
     }
     catch (JSONException jse)

--- a/src/pt/webdetails/cda/cache/Query.java
+++ b/src/pt/webdetails/cda/cache/Query.java
@@ -142,10 +142,26 @@ public abstract class Query implements Serializable
     return parameters;
   }
 
+  public String getParametersAsString()
+  {
+	 String p = "";
+    for (CachedParam param : getParameters())
+    {
+	   p += param.getName() + ':' + param.getValue() + ';';
+    }
+    return p;
+  }
+
 
   public void setParameters(List<CachedParam> parameters)
   {
     this.parameters = parameters;
+  }
+
+  /* Doesn't do anything.  Provides congruence with getParametersAsString for
+	* hibernate. */
+  public void setParametersAsString(String parameters)
+  {
   }
 
 


### PR DESCRIPTION
Adds a new params column to the cda_cacheControl table which contains
the parameters as a string.

Set a unique constraint on (cdaFile, dataAccessId, userName, cronString,
params) to prevent duplicate cron jobs from being created.

_Is this too hacky?_
