### PR TITLE
[CDA-81] Multi-tenancy does not work with CDA cache enabled

### DIFF
--- a/cda-core/src/pt/webdetails/cda/cache/CacheKey.java
+++ b/cda-core/src/pt/webdetails/cda/cache/CacheKey.java
@@ -1,0 +1,200 @@
+/*!
+* Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+*
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+package pt.webdetails.cda.cache;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class CacheKey implements Serializable {
+
+  private static final long serialVersionUID = -1273843592305584696L;
+
+  private ArrayList<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>();
+
+  public CacheKey() {
+  }
+
+  public CacheKey( String key, String value ) {
+    addKeyValuePair( key, value );
+  }
+
+  public ArrayList<KeyValuePair> getKeyValuePairs() {
+    if ( keyValuePairs == null ) {
+      keyValuePairs = new ArrayList<KeyValuePair>();
+    }
+    return keyValuePairs;
+  }
+
+  public void addKeyValuePair( String key, String value ) {
+    if ( !StringUtils.isEmpty( key ) && getByKey( key ) == null ) {
+      getKeyValuePairs().add( new KeyValuePair( key, value ) );
+    }
+  }
+
+  public void removeByKey( String key ) {
+    if ( !StringUtils.isEmpty( key ) ) {
+      for ( KeyValuePair pair : getKeyValuePairs() ) {
+        if ( key.equals( pair.getKey() ) ) {
+          getKeyValuePairs().remove( pair );
+        }
+      }
+    }
+  }
+
+  public KeyValuePair getByKey( String key ) {
+    if ( !StringUtils.isEmpty( key ) ) {
+      for ( KeyValuePair pair : getKeyValuePairs() ) {
+        if ( key.equals( pair.getKey() ) ) {
+          return pair;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals( final Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
+
+    final CacheKey other = (CacheKey) o;
+
+    if ( keyValuePairs != null ? !keyValuePairs.equals( other.keyValuePairs ) : other.keyValuePairs != null ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 7;
+
+    for ( KeyValuePair pair : getKeyValuePairs() ) {
+      result = 7 * result + ( pair != null ? pair.hashCode() : 0 );
+    }
+
+    return result;
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuffer sb = new StringBuffer();
+
+    for ( KeyValuePair pair : getKeyValuePairs() ) {
+      sb.append( pair != null ? pair.toString() : "null" );
+    }
+
+    return CacheKey.class.getName() + " [" + hashCode() + "]\n" + sb.toString();
+  }
+
+  @Override
+  public CacheKey clone() {
+    CacheKey clone = new CacheKey();
+    for( KeyValuePair pair : getKeyValuePairs() ){
+      clone.addKeyValuePair( pair.getKey() , pair.getValue() );
+    }
+    return clone;
+  }
+
+  public class KeyValuePair implements Serializable {
+
+    private static final long serialVersionUID = -6692451693938049364L;
+
+    private String key;
+    private String value;
+
+    public KeyValuePair( String key, String value ) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public void setKey( String key ) {
+      this.key = key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue( String value ) {
+      this.value = value;
+    }
+
+    public boolean equals( final Object o ) {
+
+      if ( this == o ) {
+        return true;
+      }
+      if ( o == null || getClass() != o.getClass() ) {
+        return false;
+      }
+
+      final KeyValuePair other = (KeyValuePair) o;
+
+      if ( this.key == null ? other.key != null : !this.key.equals( other.key ) ) {
+        return false;
+      }
+
+      if ( this.value == null ? other.value != null : !this.value.equals( other.value ) ) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = 7;
+      result = 31 * result + ( key != null ? key.hashCode() : 0 );
+      result = 31 * result + ( value != null ? value.hashCode() : 0 );
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return this.getClass().getName() + " [" + hashCode() + "]\n\tKey:[" + getKey() + "]\n\tValue:[" + getValue()
+        + "]\n";
+    }
+
+  /*
+   * Serializable classes that require special handling during the serialization and deserialization process should
+   * implement the following methods: writeObject(java.io.ObjectOutputStream stream),
+   * readObject(java.io.ObjectInputStream stream)
+   *
+   * @see http://docs.oracle.com/javase/6/docs/api/java/io/ObjectInputStream.html
+   */
+
+    private void readObject( java.io.ObjectInputStream in ) throws IOException, ClassNotFoundException {
+      key = (String) in.readObject();
+      value = (String) in.readObject();
+    }
+
+    private void writeObject( java.io.ObjectOutputStream out ) throws IOException {
+      out.writeObject( key );
+      out.writeObject( value );
+    }
+  }
+}

--- a/cda-core/src/pt/webdetails/cda/cache/DataAccessCacheElementParser.java
+++ b/cda-core/src/pt/webdetails/cda/cache/DataAccessCacheElementParser.java
@@ -1,0 +1,130 @@
+/*!
+* Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+*
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+package pt.webdetails.cda.cache;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.dom4j.Element;
+import pt.webdetails.cda.utils.FormulaEvaluator;
+
+import java.util.List;
+
+public class DataAccessCacheElementParser {
+
+  // default value for cacheEnabled is true for DataAccess/Cache node
+  public static final boolean DEFAULT_CACHE_ENABLED = true;
+  private boolean cacheEnabled = DEFAULT_CACHE_ENABLED;
+  private static final Log logger = LogFactory.getLog( DataAccessCacheElementParser.class );
+  private static final String ATTR_CACHE_ENABLED = "enabled"; //$NON-NLS-1$
+  private static final String ATTR_DURATION = "duration"; //$NON-NLS-1$
+  private static final String ATTR_KEY_NAME = "name"; //$NON-NLS-1$
+  private static final String ATTR_KEY_VALUE = "value"; //$NON-NLS-1$
+  private static final String ATTR_KEY_DEFAULT_VALUE = "default"; //$NON-NLS-1$
+  private Integer cacheDuration;
+  private CacheKey cacheKey = new CacheKey(); // DataAccess/Cache/Key nodes
+  private Element element; // DataAccess/Cache node
+
+
+  public DataAccessCacheElementParser( Element element ) {
+    this.element = element;
+    this.cacheEnabled = DEFAULT_CACHE_ENABLED;
+  }
+
+  public boolean parse() {
+
+    boolean success = false;
+
+    try {
+
+      // default is true; we change it *only* if it has been explicitly set to false
+      if ( contains( element, ATTR_CACHE_ENABLED )
+        && element.attributeValue( ATTR_CACHE_ENABLED ).toString().equalsIgnoreCase( "false" ) ) {
+        setCacheEnabled( false );
+      }
+
+      if ( contains( element, ATTR_DURATION ) && isValidPositiveInteger(
+        element.attributeValue( ATTR_DURATION ).toString() ) ) {
+        setCacheDuration( Integer.parseInt( element.attributeValue( ATTR_DURATION ).toString() ) );
+      }
+
+      @SuppressWarnings( "unchecked" )
+      List<Element> keyNodes = element.selectNodes( "Key" ); //$NON-NLS-1$
+
+      if ( keyNodes != null ) {
+
+        for ( Element keyNode : keyNodes ) {
+          buildKeyValuePair( keyNode );
+        }
+      }
+
+      success = true;
+
+    } catch ( Exception e ) {
+      logger.error( e.getMessage(), e );
+    }
+
+    return success;
+  }
+
+  private void buildKeyValuePair( Element keyNode ) {
+
+    // minimum required: name and value
+    if ( keyNode != null && contains( keyNode, ATTR_KEY_NAME ) && contains( keyNode, ATTR_KEY_VALUE ) ) {
+
+      String key = keyNode.attributeValue( ATTR_KEY_NAME ).toString();
+
+      String value = FormulaEvaluator.replaceFormula( keyNode.attributeValue( ATTR_KEY_VALUE ).toString() );
+
+      // if no value was fetched from formula AND user defined a default-value, we apply it
+      if ( StringUtils.isEmpty( value ) || value.trim().equals( "null" )
+        && keyNode.attributeValue( ATTR_KEY_DEFAULT_VALUE ) != null ) {
+        value = keyNode.attributeValue( ATTR_KEY_DEFAULT_VALUE ).toString();
+      }
+
+      getCacheKey().addKeyValuePair( key, value );
+    }
+  }
+
+  private boolean contains( Element elem, String attr ) {
+    return elem != null && !StringUtils.isEmpty( elem.attributeValue( attr ) );
+  }
+
+  private boolean isValidPositiveInteger( String value ) {
+    try {
+      return Integer.parseInt( value ) > -1;
+    } catch ( Exception e ) {
+      return false;
+    }
+  }
+
+  public boolean isCacheEnabled() {
+    return cacheEnabled;
+  }
+
+  public void setCacheEnabled( boolean cacheEnabled ) {
+    this.cacheEnabled = cacheEnabled;
+  }
+
+  public Integer getCacheDuration() {
+    return cacheDuration;
+  }
+
+  public void setCacheDuration( Integer cacheDuration ) {
+    this.cacheDuration = cacheDuration;
+  }
+
+  public CacheKey getCacheKey() {
+    return cacheKey;
+  }
+}

--- a/cda-core/src/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
@@ -18,11 +18,14 @@ import org.apache.commons.logging.LogFactory;
 import org.dom4j.Element;
 import org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.AbstractNamedMDXDataFactory;
 import org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.DenormalizedMDXDataFactory;
+import pt.webdetails.cda.cache.CacheKey;
 import pt.webdetails.cda.connections.mondrian.AbstractMondrianConnection;
 import pt.webdetails.cda.connections.mondrian.MondrianConnectionInfo;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implementation of a DataAccess that will get data from a SQL database
@@ -58,7 +61,12 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
       logger.error( "Failed to get a connection info for cache key" );
       mci = null;
     }
-    return new ExtraCacheKey( mci.getMondrianRole() );
+
+    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+
+    cacheKey.addKeyValuePair( "roles" , mci.getMondrianRole() );
+
+    return cacheKey;
   }
 
   protected static class ExtraCacheKey implements Serializable {

--- a/cda-core/src/pt/webdetails/cda/dataaccess/KettleDataAccess.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/KettleDataAccess.java
@@ -22,12 +22,14 @@ import org.pentaho.reporting.libraries.resourceloader.ResourceKeyCreationExcepti
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
 import pt.webdetails.cda.CdaEngine;
+import pt.webdetails.cda.cache.CacheKey;
 import pt.webdetails.cda.connections.ConnectionCatalog.ConnectionType;
 import pt.webdetails.cda.connections.InvalidConnectionException;
 import pt.webdetails.cda.connections.kettle.KettleConnection;
 import pt.webdetails.cda.settings.CdaSettings;
 import pt.webdetails.cda.settings.UnknownConnectionException;
 
+import java.io.Serializable;
 /**
  * Todo: Document me!
  * <p/>
@@ -89,7 +91,12 @@ public class KettleDataAccess extends PREDataAccess
    * We only use solution paths, only the path needs to be stored.
    */
   @Override
-  public String getExtraCacheKey(){
-    return path;
+  public Serializable getExtraCacheKey(){
+
+    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+
+    cacheKey.addKeyValuePair( "path", path );
+
+    return cacheKey;
   }
 }

--- a/cda-core/src/pt/webdetails/cda/dataaccess/MdxDataAccess.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/MdxDataAccess.java
@@ -20,6 +20,7 @@ import org.pentaho.reporting.engine.classic.core.DataFactory;
 import org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.AbstractNamedMDXDataFactory;
 import org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.BandedMDXDataFactory;
 import pt.webdetails.cda.CdaEngine;
+import pt.webdetails.cda.cache.CacheKey;
 import pt.webdetails.cda.connections.InvalidConnectionException;
 import pt.webdetails.cda.connections.mondrian.AbstractMondrianConnection;
 import pt.webdetails.cda.connections.mondrian.MondrianConnection;
@@ -29,6 +30,8 @@ import pt.webdetails.cda.utils.mondrian.CompactBandedMDXDataFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -131,7 +134,13 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
       logger.error( "Failed to get a connection info for cache key" );
       mci = null;
     }
-    return new ExtraCacheKey( bandedMode, mci.getMondrianRole() );
+
+    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+
+    cacheKey.addKeyValuePair( "bandedMode" , bandedMode.toString() );
+    cacheKey.addKeyValuePair( "mondrianRole" ,  mci.getMondrianRole() );
+
+    return cacheKey;
   }
 
 

--- a/cda-core/src/pt/webdetails/cda/dataaccess/SimpleDataAccess.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/SimpleDataAccess.java
@@ -269,17 +269,6 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
     return tm;
   }
 
-
-  /**
-   * Extra arguments to be used for the cache key. Defaults to null but classes
-   * that extend SimpleDataAccess may decide to implement it
-   *
-   * @return
-   */
-  protected Serializable getExtraCacheKey() {
-    return null;
-  }
-
   //TODO:
 
   /**

--- a/cda-core/test-resources/repository/sample-user-defined-cacheKeys.cda
+++ b/cda-core/test-resources/repository/sample-user-defined-cacheKeys.cda
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CDADescriptor>
+
+    <!-- DataSource definition. 
+	
+	Type controls what the datasource type is.
+	The connection and query controls how the data is fetched. These values
+	are specific to each access type
+
+	-->
+    <DataSources>
+        <Connection id="1" type="sql.jdbc">
+            <Driver>org.hsqldb.jdbcDriver</Driver>
+            <Url>jdbc:hsqldb:res:sampledata</Url>
+            <User>sa</User>
+            <Pass></Pass>
+        </Connection>
+    </DataSources>
+  <!-- DataAccess object controls the query itself
+
+      Access controls if the datasource can be seen from the outside or is to
+      be used from a Compound datasource only
+
+      -->
+
+    <DataAccess id="1" connection="1" type="sql" access="public" cache="true" cacheDuration="5">
+      <Cache enabled="true" duration="500">
+          <Key name="foo" value="bar" /> 
+          <Key name="another-cache-key" value="another-cache-value" /> 
+
+          <!-- the following are properly working examples of formula cache keys for session , security and system --> 
+          <!-- <Key name="data-access-roles" value="${[system:data-access/settings.xml{data-access-roles}]}" default="data-access-roles" /> -->
+          <!-- <Key name="user-in-session" value="${[security:principalName]}" default="user-in-session"/> -->
+          <!-- <Key name="tenantId" value="${[session:org.pentaho.tenantId]}" default="default-tenant"/> -->          
+      </Cache>
+      <Name>User Roles</Name>
+      <Query><![CDATA[select distinct ${param} as inputParam from orderfact]]></Query>
+      <Parameters>
+        <Parameter name="param" type="String" default="${[session:value]}" />
+      </Parameters>
+    </DataAccess>
+</CDADescriptor>

--- a/cda-core/test-src/pt/webdetails/cda/tests/UserDefinedCacheKeysTest.java
+++ b/cda-core/test-src/pt/webdetails/cda/tests/UserDefinedCacheKeysTest.java
@@ -1,0 +1,112 @@
+/*!
+* Copyright 2002 - 2013 Webdetails, a Pentaho company.  All rights reserved.
+* 
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+
+package pt.webdetails.cda.tests;
+
+import junit.framework.Assert;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+import org.pentaho.reporting.libraries.formula.DefaultFormulaContext;
+import org.pentaho.reporting.libraries.formula.FormulaContext;
+import pt.webdetails.cda.CdaEngine;
+import pt.webdetails.cda.InitializationException;
+import pt.webdetails.cda.cache.CacheKey;
+import pt.webdetails.cda.cache.IQueryCache;
+import pt.webdetails.cda.cache.TableCacheKey;
+import pt.webdetails.cda.query.QueryOptions;
+import pt.webdetails.cda.settings.CdaSettings;
+
+import javax.swing.table.TableModel;
+
+public class UserDefinedCacheKeysTest extends CdaTestCase {
+
+  private static final String CDA_SAMPLE_FILE = "sample-user-defined-cacheKeys.cda";
+
+  private static final String CACHE_KEY = "foo";
+  private static final String CACHE_VALUE = "bar";
+
+  private static final Log logger = LogFactory.getLog( UserDefinedCacheKeysTest.class );
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    CdaEngine.init( new FormulaTestEnvironment() );
+  }
+
+  @Test
+  public void testUserDefinedCacheKeys() throws Exception {
+
+    final CdaSettings cdaSettings = parseSettingsFile( CDA_SAMPLE_FILE );
+
+    IQueryCache cache = getEnvironment().getQueryCache();
+    logger.info( "Cache cleared." );
+    cache.clearCache();
+
+    QueryOptions queryOptions = new QueryOptions();
+    queryOptions.setDataAccessId( "1" );
+    logger.info(
+      "Performing query with id=1 @ " + cdaSettings.getDataAccess( queryOptions.getDataAccessId() )
+        .toString()
+    );
+    TableModel tableModel = cdaSettings.getDataAccess( queryOptions.getDataAccessId() ).doQuery( queryOptions );
+    logger.info( "query done" );
+
+    assertNotNull( cache.getKeys() );
+    logger.info( "Query was cached" );
+
+    for ( TableCacheKey key : cache.getKeys() ) {
+
+      assertNotNull( key );
+      logger.info( "key: " + key.toString() );
+      assertNotNull( key.getExtraCacheKey() );
+      Assert.assertTrue( key.getExtraCacheKey() != null && key.getExtraCacheKey() instanceof CacheKey );
+      Assert.assertTrue( ( ( CacheKey ) key.getExtraCacheKey() ).getKeyValuePairs() != null
+        && ( ( CacheKey ) key.getExtraCacheKey() ).getKeyValuePairs().size() > 0  );
+
+      boolean hasValueAsCacheExtraKey = false;
+
+      logger.info( "Iterating extra cache keys.." );
+      for ( CacheKey.KeyValuePair pair : ( ( CacheKey ) key.getExtraCacheKey() ).getKeyValuePairs() ) {
+        logger.info( "key: " + pair.toString() );
+        if( pair.getKey().equals( CACHE_KEY ) && pair.getValue().equals( CACHE_VALUE ) ){
+          hasValueAsCacheExtraKey = true;
+        }
+      }
+
+      Assert.assertTrue( hasValueAsCacheExtraKey );
+
+    }
+  }
+
+  public static class FormulaTestEnvironment extends CdaTestEnvironment {
+
+    public FormulaTestEnvironment() throws InitializationException {
+      super( new CdaTestingContentAccessFactory() );
+    }
+
+    public FormulaContext getFormulaContext() {
+      return new TestFormulaContext();
+    }
+  }
+
+  public static class TestFormulaContext extends DefaultFormulaContext {
+    public Object resolveReference( Object name ) {
+      if ( name instanceof String && "session:value".equals( (String) name ) ) {
+        return "thisIsAGoodValue";
+      }
+      return super.resolveReference( name );
+    }
+  }
+
+}


### PR DESCRIPTION
- added functionality: ability to define CDA cache keys for each dataAccess

``` xml
<DataAccess>
     <Cache enabled="true" duration="500">
         <Key name="tenantId" value="${[session:org.pentaho.tenantId]}" default="/pentaho/tenant0"/>
     </Cache>
</DataAccess>
```
