### PR TITLE
Fixed cutting entries in union data access when pageSize is defined

### DIFF
--- a/cda-core/src/pt/webdetails/cda/dataaccess/UnionCompoundDataAccess.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/UnionCompoundDataAccess.java
@@ -72,8 +72,8 @@ public class UnionCompoundDataAccess extends CompoundDataAccess
       croppedOptions.setSortBy(new ArrayList<String>());
       croppedOptions.setPageSize(0);
       croppedOptions.setPageStart(0);
-      final TableModel tableModelA = this.getCdaSettings().getDataAccess(topId).doQuery(queryOptions);
-      final TableModel tableModelB = this.getCdaSettings().getDataAccess(bottomId).doQuery(queryOptions);
+      final TableModel tableModelA = this.getCdaSettings().getDataAccess(topId).doQuery(croppedOptions);
+      final TableModel tableModelB = this.getCdaSettings().getDataAccess(bottomId).doQuery(croppedOptions);
 
       return TableModelUtils.appendTableModel(tableModelA, tableModelB);
 


### PR DESCRIPTION
Hi!

I think someone forgot to pass `croppedOptions` over to `doQuery` method. Without resetting `pageSize` and `pageStart` union query returns incomplete rows.
