### PR TITLE
[CDA-99] Connections type olap4j.defaultolap4j

### DIFF
--- a/cda-core/src/pt/webdetails/cda/dataaccess/DataAccessEnums.java
+++ b/cda-core/src/pt/webdetails/cda/dataaccess/DataAccessEnums.java
@@ -14,6 +14,8 @@
 package pt.webdetails.cda.dataaccess;
 
 
+import java.util.Arrays;
+
 public class DataAccessEnums {
 
 
@@ -72,7 +74,7 @@ public class DataAccessEnums {
     MONDRIAN_JDBC("mondrian.jdbc"),
     MONDRIAN_JNDI("mondrian.jndi"),
     
-    OLAP4J("olap4j"),
+    OLAP4J( new String[]{ "olap4j" , "olap4j.defaultolap4j" } ),
     
     SCRIPTING("scripting.scripting"),
     
@@ -80,16 +82,26 @@ public class DataAccessEnums {
     
     KETTLE_TRANS_FROM_FILE("kettle.TransFromFile");
     
-    private String type;
-    public String getType() { return this.type; }
-    ConnectionInstanceType(String type){
-      this.type = type;
+    private String[] types;
+    public String[] getTypes() { return this.types; }
+    ConnectionInstanceType( String type ){
+      this( new String[]{ type } );
     }
     
-    public static ConnectionInstanceType parseType(String type){
+    ConnectionInstanceType( String[] types ){
+      this.types = types;
+    }
+
+    public static ConnectionInstanceType parseType( String type ){
+      return parseType( new String[]{ type } );
+    }
+
+    public static ConnectionInstanceType parseType( String[] types ){
       for (ConnectionInstanceType connection : ConnectionInstanceType.values()) {
-        if (connection.getType().equals(type)) {
-          return connection;
+        for( String type : types ) {
+          if ( Arrays.asList( connection.getTypes() ).contains( type ) ) {
+            return connection;
+          }
         }
       }
       return null;

--- a/cda-core/test-resources/repository/sample-olap4j.cda
+++ b/cda-core/test-resources/repository/sample-olap4j.cda
@@ -18,6 +18,17 @@
             <Property name="JdbcDrivers">org.hsqldb.jdbcDriver</Property>
             <Property name="Catalog">res:repository/steelwheels.mondrian.xml</Property>
         </Connection>
+
+        <!-- same as connection id 2, but using new connection type olap4j.defaultolap4j -->
+        <Connection id="3" type="olap4j.defaultolap4j">
+            <Driver>mondrian.olap4j.MondrianOlap4jDriver</Driver>
+            <Url>jdbc:mondrian:</Url>
+            <Property name="JdbcUser">pentaho_user</Property>
+            <Property name="JdbcPassword">password</Property>
+            <Property name="Jdbc">jdbc:hsqldb:res:sampledata</Property>
+            <Property name="JdbcDrivers">org.hsqldb.jdbcDriver</Property>
+            <Property name="Catalog">res:repository/steelwheels.mondrian.xml</Property>
+        </Connection>
     </DataSources>
     <!-- DataAccess object controls the query itself
 
@@ -49,4 +60,32 @@
 			</CalculatedColumn>
 		</Columns>
     </DataAccess>
+
+
+    <!-- same as data access id 2, but using new connection id 3, which has been defined using new type olap4j.defaultolap4j -->
+    <DataAccess id="3" connection="3" type="olap4j" access="public" cache="true" cacheDuration="3600" >
+		<Name>Sample query on SteelWheelsSales</Name>
+        <Query><![CDATA[
+			select {[Measures].[Sales]} ON COLUMNS,
+			NON EMPTY  [Time].Children ON ROWS
+			from [SteelWheelsSales]
+			where ([Order Status].[${status}])
+		]]></Query>
+        <Parameters>
+            <Parameter name="status" type="String" default="In Process"/>
+        </Parameters>
+		<Columns>
+			<Column idx="1">
+				<Name>Year</Name>
+			</Column>
+			<Column idx="2">
+				<Name>price</Name>
+			</Column>
+			<CalculatedColumn>
+				<Name>PriceInK</Name>
+				<Formula>=[price]/1000000</Formula>
+			</CalculatedColumn>
+		</Columns>
+    </DataAccess>
+
 </CDADescriptor>

--- a/cda-core/test-src/pt/webdetails/cda/tests/Olap4jTest.java
+++ b/cda-core/test-src/pt/webdetails/cda/tests/Olap4jTest.java
@@ -77,4 +77,25 @@ public class Olap4jTest extends CdaTestCase
     logger.info("Found Query in Cache!");
 
   }
+
+  /**
+   * this test is the same as testOlap4jQuery(), but now calls for a new data-access id 3, which in its turn
+   * is set to use the new connection id 3, that has been defined to use new type 'olap4j.defaultolap4j'
+   * @throws Exception should something go wrong
+   */
+  public void testDefaultOlap4jQuery() throws Exception
+  {
+
+    final CdaSettings cdaSettings = parseSettingsFile("sample-olap4j.cda");
+    logger.debug("Doing query on Cda - Initializing CdaEngine");
+    final CdaEngine engine = CdaEngine.getInstance();
+
+    final QueryOptions queryOptions = new QueryOptions();
+    queryOptions.setDataAccessId("3"); // same as data-access id 2, but using new connection type 'olap4j.defaultolap4j'
+    queryOptions.setOutputType("json");
+    queryOptions.addParameter("status", "Shipped");
+
+    logger.info("Doing query");
+    engine.doQuery(cdaSettings, queryOptions);
+  }
 }


### PR DESCRIPTION
```
- DataAccessEnums now assigns an array of connection types instead of a single one ( to encompass 'olap4j' and 'olap4j.defaultolap4j' for OLAP4J enum connection type )
- added unit test accordingly
```
