### PR TITLE
[CLEANUP] ensuring runtime-lib gets deleted when 'clean-all' ant targ…

### DIFF
--- a/cda-core/build.xml
+++ b/cda-core/build.xml
@@ -137,4 +137,8 @@
     </copy>
   </target>
 
+  <target name="clean-all" depends="subfloor.clean-all">
+    <delete dir="${runtimelib.dir}" />
+  </target>
+
 </project>


### PR DESCRIPTION
…et is called

	- failure to do so was leaving behind deprecated jars within /runtime-lib
	- ant 'resolve' target is already re-creating /runtime-lib