### PR TITLE
[BACKLOG-10623] Update Spring Framework

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
     <dependency.slf4j-log4j12.revision>1.5.8</dependency.slf4j-log4j12.revision>
     <dependency.jxl.revision>2.6.12</dependency.jxl.revision>
     <dependency.jsr311-api.revision>1.1-ea</dependency.jsr311-api.revision>
-    <dependency.spring.framework.revision>3.2.14.RELEASE</dependency.spring.framework.revision>
+    <dependency.spring.framework.revision>4.3.2.RELEASE</dependency.spring.framework.revision>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This is part of a set of pull requests for the spring 4 upgrade work:
https://github.com/pentaho/pentaho-platform/pull/3104
https://github.com/webdetails/cpf/pull/98
https://github.com/webdetails/cdf/pull/870
https://github.com/webdetails/cda/pull/209
https://github.com/webdetails/cde/pull/718
https://github.com/pentaho/data-access/pull/783
https://github.com/pentaho/pentaho-reporting/pull/828
https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/436
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/842
https://github.com/pentaho/marketplace/pull/115
https://github.com/pentaho/big-data-plugin/pull/739
https://github.com/pentaho/pentaho-platform-ee/pull/972
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/477
https://github.com/pentaho/pentaho-platform-plugin-dashboards/pull/319
https://github.com/pentaho/pdi-ee-plugin/pull/321
https://github.com/pentaho/pentaho-analyzer/pull/1196
https://github.com/pentaho/pdi-scheduler-plugin/pull/36
https://github.com/pentaho/pentaho-platform-plugin-geo/pull/114
https://github.com/pentaho/pentaho-metadata-editor/pull/70
https://github.com/pentaho/pentaho-aggdesigner/pull/46
https://github.com/webdetails/cpk/pull/51
https://github.com/pentaho/pentaho-osgi-bundles/pull/141
https://github.com/pentaho/pentaho-karaf-assembly/pull/231