### PR TITLE
[BACKLOG-25456] Jetty websocket implementation

### DIFF
--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -15,7 +15,7 @@
   <packaging>bundle</packaging>
 
   <properties>
-    <jettyVersion>8.1.15.v20140411</jettyVersion>
+    <jetty.version>8.1.15.v20140411</jetty.version>
   </properties>
 
   <dependencies>
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-websocket</artifactId>
-      <version>${jettyVersion}</version>
+      <version>${jetty.version}</version>
     </dependency>
 
     <dependency>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -14,6 +14,10 @@
   <artifactId>cda-osgi-impl</artifactId>
   <packaging>bundle</packaging>
 
+  <properties>
+    <jettyVersion>8.1.15.v20140411</jettyVersion>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>pentaho</groupId>
@@ -83,6 +87,21 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-websocket</artifactId>
+      <version>${jettyVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
@@ -1,0 +1,24 @@
+package org.pentaho.ctools.cda.endpoints;
+
+import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.WebSocketServlet;
+import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class CdaJettyWebSocketServlet extends WebSocketServlet {
+  public WebSocket doWebSocketConnect( HttpServletRequest request, String subprotocol ) {
+    if ( WebsocketJsonQueryEndpoint.ACCEPTED_SUB_PROTOCOL.equals( subprotocol ) ) {
+      return new CdaJettyWebsocket( request, new WebsocketJsonQueryEndpoint() );
+    }
+
+    // returns 503 SERVICE UNAVAILABLE
+    return null;
+  }
+
+  @Override
+  public boolean checkOrigin( HttpServletRequest request, String origin ) {
+    // TODO Cross-domain origin logic
+    return true;
+  }
+}

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
@@ -1,3 +1,15 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 package org.pentaho.ctools.cda.endpoints;
 
 import org.eclipse.jetty.websocket.WebSocket;

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
@@ -1,3 +1,15 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 package org.pentaho.ctools.cda.endpoints;
 
 import org.apache.commons.logging.Log;
@@ -40,7 +52,7 @@ public class CdaJettyWebsocket implements WebSocket.OnTextMessage {
     } catch ( Exception e ) {
       logger.error( "Error sending message. Closing websocket...", e );
 
-      // 1011:	Server error
+      // 1011: Server error
       // The server is terminating the connection because
       // it encountered an unexpected condition that prevented it from
       // fulfilling the request.

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
@@ -1,0 +1,50 @@
+package org.pentaho.ctools.cda.endpoints;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.jetty.websocket.WebSocket;
+import pt.webdetails.cda.push.IWebsocketEndpoint;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class CdaJettyWebsocket implements WebSocket.OnTextMessage {
+  private static final Log logger = LogFactory.getLog( CdaJettyWebsocket.class );
+
+  private Connection connection;
+
+  private final HttpServletRequest request;
+  private final IWebsocketEndpoint websocketJsonQueryEndpoint;
+
+  CdaJettyWebsocket( HttpServletRequest request, IWebsocketEndpoint websocketJsonQueryEndpoint ) {
+    this.request = request;
+    this.websocketJsonQueryEndpoint = websocketJsonQueryEndpoint;
+  }
+
+  public void onOpen( Connection connection ) {
+    this.connection = connection;
+
+    this.websocketJsonQueryEndpoint.onOpen( this::processOutboundMessage );
+  }
+
+  public void onMessage( String query ) {
+    this.websocketJsonQueryEndpoint.onMessage( query, this::processOutboundMessage );
+  }
+
+  public void onClose( int closeCode, String message ) {
+    this.websocketJsonQueryEndpoint.onClose();
+  }
+
+  private void processOutboundMessage( String outboundMessage ) {
+    try {
+      this.connection.sendMessage( outboundMessage );
+    } catch ( Exception e ) {
+      logger.error( "Error sending message. Closing websocket...", e );
+
+      // 1011:	Server error
+      // The server is terminating the connection because
+      // it encountered an unexpected condition that prevented it from
+      // fulfilling the request.
+      this.connection.close( 1011, "Error while sending message." );
+    }
+  }
+}

--- a/osgi/src/main/resources-filtered/OSGI-INF/blueprint/blueprint-cda-core.xml
+++ b/osgi/src/main/resources-filtered/OSGI-INF/blueprint/blueprint-cda-core.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cxf="http://cxf.apache.org/blueprint/core"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
                                http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                                http://cxf.apache.org/blueprint/core
                                http://cxf.apache.org/blueprint/jaxrs
                                http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
 
@@ -97,5 +99,14 @@
       <bean class="pt.webdetails.cda.endpoints.RestEndpoint"/>
     </jaxrs:serviceBeans>
   </jaxrs:server>
+
+  <service id="jettyWebSocketServlet" interface="javax.servlet.Servlet">
+    <service-properties>
+      <entry key="alias" value="/cda/websocket/query" />
+      <entry key="servlet-name" value="CDA Jetty WebSocket Servlet" />
+    </service-properties>
+
+    <bean class="org.pentaho.ctools.cda.endpoints.CdaJettyWebSocketServlet" />
+  </service>
 
 </blueprint>

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
@@ -1,0 +1,60 @@
+package org.pentaho.ctools.cda.endpoints;
+
+import org.eclipse.jetty.websocket.WebSocket;
+import org.junit.Before;
+import org.junit.Test;
+import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class CdaJettyWebSocketServletTest {
+  private HttpServletRequest mockRequest;
+
+  private CdaJettyWebSocketServlet servlet;
+
+  @Before
+  public void setUp() {
+    this.mockRequest = mock( HttpServletRequest.class );
+
+    this.servlet = new CdaJettyWebSocketServlet();
+  }
+
+  @Test
+  public void doWebSocketConnectKnownSubprotocol() {
+    String subprotocol = WebsocketJsonQueryEndpoint.ACCEPTED_SUB_PROTOCOL;
+
+    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+
+    assertNotNull( webSocket );
+  }
+
+  @Test
+  public void doWebSocketConnectUnknownSubprotocol() {
+    String subprotocol = "Unknown-protocol-for-tests";
+
+    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+
+    assertNull( webSocket );
+  }
+
+  @Test
+  public void doWebSocketConnectNullSubprotocol() {
+    String subprotocol = null;
+
+    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+
+    assertNull( webSocket );
+  }
+
+  @Test
+  public void checkOriginAlwaysTrue() {
+    String originUri = "http://for-now-any-url-should-return-true";
+
+    assertTrue( this.servlet.checkOrigin( this.mockRequest, originUri ) );
+  }
+}

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
@@ -1,3 +1,15 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 package org.pentaho.ctools.cda.endpoints;
 
 import org.eclipse.jetty.websocket.WebSocket;

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
@@ -1,0 +1,79 @@
+package org.pentaho.ctools.cda.endpoints;
+
+import org.eclipse.jetty.websocket.WebSocket;
+import org.junit.Before;
+import org.junit.Test;
+import pt.webdetails.cda.push.IWebsocketEndpoint;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CdaJettyWebsocketTest {
+  public static final String OUTBOUND_MESSAGE_1 = "Outbound Message 1";
+  public static final String OUTBOUND_MESSAGE_2 = "Outbound Message 2";
+
+  public static final String INBOUND_MESSAGE = "Inbound Message 1";
+
+  private HttpServletRequest mockRequest;
+  private IWebsocketEndpoint mockPlatformWebsocketEndpoint;
+
+  private CdaJettyWebsocket websocket;
+
+  @Before
+  public void setUp() {
+    this.mockRequest = mock( HttpServletRequest.class );
+    this.mockPlatformWebsocketEndpoint = mock( IWebsocketEndpoint.class );
+
+    this.websocket = new CdaJettyWebsocket( this.mockRequest, this.mockPlatformWebsocketEndpoint );
+  }
+
+  @Test
+  public void onOpen() {
+    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
+    this.websocket.onOpen( mockConnection );
+
+    verify( this.mockPlatformWebsocketEndpoint, times( 1 ) ).onOpen( any( Consumer.class ) );
+  }
+
+  @Test
+  public void onOpenMaySendMessages() throws IOException {
+    doAnswer( invocation -> {
+      Consumer<String> outboundMessageConsumer = (Consumer<String>) invocation.getArguments()[ 0 ];
+      outboundMessageConsumer.accept( OUTBOUND_MESSAGE_1 );
+      outboundMessageConsumer.accept( OUTBOUND_MESSAGE_2 );
+
+      return null;
+    } ).when( this.mockPlatformWebsocketEndpoint ).onOpen( any( Consumer.class ) );
+
+    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
+    this.websocket.onOpen( mockConnection );
+
+    verify( mockConnection, times( 1 ) ).sendMessage( OUTBOUND_MESSAGE_1 );
+    verify( mockConnection, times( 1 ) ).sendMessage( OUTBOUND_MESSAGE_2 );
+  }
+
+  @Test
+  public void onMessage() {
+    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
+    this.websocket.onOpen( mockConnection );
+
+    this.websocket.onMessage( INBOUND_MESSAGE );
+
+    verify( this.mockPlatformWebsocketEndpoint, times( 1 ) ).onMessage( same( INBOUND_MESSAGE ), any( Consumer.class ) );
+  }
+
+  @Test
+  public void onClose() {
+    this.websocket.onClose( 1000, "" );
+
+    verify( this.mockPlatformWebsocketEndpoint, times( 1 ) ).onClose();
+  }
+}

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
@@ -1,3 +1,15 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
 package org.pentaho.ctools.cda.endpoints;
 
 import org.eclipse.jetty.websocket.WebSocket;


### PR DESCRIPTION
Mirrors the websocket functionality added by https://github.com/webdetails/cda/pull/281. The websocket is exposed at `/cda/websocket/query`.

@pentaho/millenniumfalcon please review.