### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,6 @@
     <dependency.jsr311-api.revision>1.1-ea</dependency.jsr311-api.revision>
     <owasp.encoder.version>1.2</owasp.encoder.version>
     <google.guava.version>17.0</google.guava.version>
-    <xercesImpl.version>2.9.1</xercesImpl.version>
     <eigenbase-properties.version>1.1.2</eigenbase-properties.version>
     <eigenbase-resgen.version>1.3.1</eigenbase-resgen.version>
 
@@ -189,7 +188,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>${xercesImpl.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
     <guava.version>17.0</guava.version>
     <dependency.com.fasterxml.jackson.core.version>2.9.5</dependency.com.fasterxml.jackson.core.version>
     <metastore.version>8.3.0.0-SNAPSHOT</metastore.version>
-    <xml-apis.version>1.3.04</xml-apis.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <websocket-api.version>1.0</websocket-api.version>
   </properties>
@@ -326,11 +325,6 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${dependency.com.fasterxml.jackson.core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>${xml-apis.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.websocket</groupId>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 