### PR TITLE
[BACKLOG-30893] Centralize commons-logging in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <javax.servlet-api>3.0.1</javax.servlet-api>
     <commons-codec.version>1.9</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-logging.version>1.1.3</commons-logging.version>
     <guava.version>17.0</guava.version>
     <metastore.version>9.0.0.0-SNAPSHOT</metastore.version>
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
@@ -279,11 +278,6 @@
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet-api}</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
Linked with this: pentaho/maven-parent-poms#163