### PR TITLE
[BACKLOG-27590] Upgrade to Karaf 4.2.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -319,6 +319,11 @@
       <version>${dependency.bsh.revision}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
[BACKLOG-30801] Kettle5-log4j plugin is using a wrong version of log4j - fixing broken tests