### PR TITLE
[PPP-4486] Use of Vulnerable Component: commons-codec [Multiple Versi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <reactivestreams.version>1.0.2</reactivestreams.version>
     <commons.beanutils.version>1.9.3</commons.beanutils.version>
     <javax.servlet-api>3.0.1</javax.servlet-api>
-    <commons-codec.version>1.9</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <guava.version>17.0</guava.version>
     <metastore.version>9.1.0.0-SNAPSHOT</metastore.version>
@@ -278,11 +277,6 @@
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet-api}</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
…ons] (sonatype-2012-0050)

Bumping `commons-codec` to version 1.14 to address multiple CVEs.
Moving dependency management to the parent POMs.

Please see https://github.com/pentaho/maven-parent-poms/pull/214 for details.