### PR TITLE
[PDI-19629] Fix unit tests

### DIFF
--- a/core/src/test/java/pt/webdetails/cda/exporter/CsvExporterTest.java
+++ b/core/src/test/java/pt/webdetails/cda/exporter/CsvExporterTest.java
@@ -39,9 +39,9 @@ public class CsvExporterTest extends AbstractKettleExporterTestBase {
     TableModel table = BasicExportExamples.getTestTable1();
     final String expected =
       "The Integer;\"The String\";The Numeric;The Date;The Calculation" + System.lineSeparator()
-        + "1;\"One\";1.05;Sun Jan 01 00:01:01 GMT 2012;-12.34567890123456789" + System.lineSeparator()
-        + "-2;\"Two > One\";-1.05;;987654321.12345678900" + System.lineSeparator()
-        + "9223372036854775807;\"Many\";1.7976931348623157E308;Thu Jan 01 00:00:00 GMT 1970;4.9E-325"
+        + "\"1\";\"One\";\"1.05\";\"Sun Jan 01 00:01:01 GMT 2012\";\"-12.34567890123456789\"" + System.lineSeparator()
+        + "\"-2\";\"Two > One\";\"-1.05\";;\"987654321.12345678900\"" + System.lineSeparator()
+        + "\"9223372036854775807\";\"Many\";\"1.7976931348623157E308\";\"Thu Jan 01 00:00:00 GMT 1970\";\"4.9E-325\""
         + System.lineSeparator();
     final String result = getCsvResult( table );
     assertEquals( expected, result );
@@ -79,9 +79,9 @@ public class CsvExporterTest extends AbstractKettleExporterTestBase {
 
   private static final String getCustomExpect1() {
     return "The Integer|'The String'|The Numeric|The Date|The Calculation" + System.lineSeparator()
-      + "1|'One'|1.05|Sun Jan 01 00:01:01 GMT 2012|-12.34567890123456789" + System.lineSeparator()
-      + "-2|'Two > One'|-1.05||987654321.12345678900" + System.lineSeparator()
-      + "9223372036854775807|'Many'|1.7976931348623157E308|Thu Jan 01 00:00:00 GMT 1970|4.9E-325"
+      + "'1'|'One'|'1.05'|'Sun Jan 01 00:01:01 GMT 2012'|'-12.34567890123456789'" + System.lineSeparator()
+      + "'-2'|'Two > One'|'-1.05'||'987654321.12345678900'" + System.lineSeparator()
+      + "'9223372036854775807'|'Many'|'1.7976931348623157E308'|'Thu Jan 01 00:00:00 GMT 1970'|'4.9E-325'"
       + System.lineSeparator();
   }
 

--- a/core/src/test/java/pt/webdetails/cda/filetests/MdxJdbcTest.java
+++ b/core/src/test/java/pt/webdetails/cda/filetests/MdxJdbcTest.java
@@ -291,7 +291,7 @@ public class MdxJdbcTest extends CdaTestCase {
 
   public void testCsvExport() throws Exception {
     String expectedOutput = "\"[Measures].[MeasuresLevel]\";Year;price" + System.lineSeparator()
-      + "\"Sales\";445094.69;564842.02" + System.lineSeparator();
+      + "\"Sales\";\"445094.69\";\"564842.02\"" + System.lineSeparator();
 
     final CdaSettings cdaSettings = parseSettingsFile( "sample-output.cda" );
 


### PR DESCRIPTION
The expected results set on the tests were wrong: as "pt.webdetails.cda.exporter.CsvExporter" sets "Force Enclosure" as 'true', it is expected that all values are surrounded by the specified enclosure character/string.
Before the fix introduced under PDI-19629, not all the values had the expected behaviour; now the application works correctly and the tests started to fail.

@renato-s @andreramos89 @bcostahitachivantara 

