### PR TITLE
[SP-6289] Backport of PDI-19629 - TextFileOutput Step Does Not Enclos…

### DIFF
--- a/core/src/test/java/pt/webdetails/cda/exporter/CsvExporterTest.java
+++ b/core/src/test/java/pt/webdetails/cda/exporter/CsvExporterTest.java
@@ -39,9 +39,9 @@ public class CsvExporterTest extends AbstractKettleExporterTestBase {
     TableModel table = BasicExportExamples.getTestTable1();
     final String expected =
       "The Integer;\"The String\";The Numeric;The Date;The Calculation" + System.lineSeparator()
-        + "1;\"One\";1.05;Sun Jan 01 00:01:01 GMT 2012;-12.34567890123456789" + System.lineSeparator()
-        + "-2;\"Two > One\";-1.05;;987654321.12345678900" + System.lineSeparator()
-        + "9223372036854775807;\"Many\";1.7976931348623157E308;Thu Jan 01 00:00:00 GMT 1970;4.9E-325"
+        + "\"1\";\"One\";\"1.05\";\"Sun Jan 01 00:01:01 GMT 2012\";\"-12.34567890123456789\"" + System.lineSeparator()
+        + "\"-2\";\"Two > One\";\"-1.05\";;\"987654321.12345678900\"" + System.lineSeparator()
+        + "\"9223372036854775807\";\"Many\";\"1.7976931348623157E308\";\"Thu Jan 01 00:00:00 GMT 1970\";\"4.9E-325\""
         + System.lineSeparator();
     final String result = getCsvResult( table );
     assertEquals( expected, result );
@@ -79,9 +79,9 @@ public class CsvExporterTest extends AbstractKettleExporterTestBase {
 
   private static final String getCustomExpect1() {
     return "The Integer|'The String'|The Numeric|The Date|The Calculation" + System.lineSeparator()
-      + "1|'One'|1.05|Sun Jan 01 00:01:01 GMT 2012|-12.34567890123456789" + System.lineSeparator()
-      + "-2|'Two > One'|-1.05||987654321.12345678900" + System.lineSeparator()
-      + "9223372036854775807|'Many'|1.7976931348623157E308|Thu Jan 01 00:00:00 GMT 1970|4.9E-325"
+      + "'1'|'One'|'1.05'|'Sun Jan 01 00:01:01 GMT 2012'|'-12.34567890123456789'" + System.lineSeparator()
+      + "'-2'|'Two > One'|'-1.05'||'987654321.12345678900'" + System.lineSeparator()
+      + "'9223372036854775807'|'Many'|'1.7976931348623157E308'|'Thu Jan 01 00:00:00 GMT 1970'|'4.9E-325'"
       + System.lineSeparator();
   }
 

--- a/core/src/test/java/pt/webdetails/cda/filetests/MdxJdbcTest.java
+++ b/core/src/test/java/pt/webdetails/cda/filetests/MdxJdbcTest.java
@@ -291,7 +291,7 @@ public class MdxJdbcTest extends CdaTestCase {
 
   public void testCsvExport() throws Exception {
     String expectedOutput = "\"[Measures].[MeasuresLevel]\";Year;price" + System.lineSeparator()
-      + "\"Sales\";445094.69;564842.02" + System.lineSeparator();
+      + "\"Sales\";\"445094.69\";\"564842.02\"" + System.lineSeparator();
 
     final CdaSettings cdaSettings = parseSettingsFile( "sample-output.cda" );
 


### PR DESCRIPTION
…e Data Field When Separator is Present (9.3 Suite)

"pt.webdetails.cda.exporter.CsvExporter" sets "Force Enclosure" as 'true'. This means that it is expected that all values are surrounded by the specified enclosure character/string.

(cherry picked from commit cc7407b230dc925d1c74a5c0343a84f53dcccddd)