### PR TITLE
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

### DIFF
--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -78,13 +78,18 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-server</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-client</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
 

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
@@ -12,8 +12,8 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
-import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
 import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
@@ -14,9 +14,10 @@ package org.pentaho.ctools.cda.endpoints;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import pt.webdetails.cda.push.IWebsocketEndpoint;
@@ -37,7 +38,7 @@ public class CdaJettyWebsocket {
     this.websocketJsonQueryEndpoint = websocketJsonQueryEndpoint;
   }
 
-  @OnWebSocketConnect
+  @OnWebSocketOpen
   public void onConnect( Session session ) {
     this.session = session;
     this.websocketJsonQueryEndpoint.onOpen( this::processOutboundMessage );
@@ -60,7 +61,7 @@ public class CdaJettyWebsocket {
 
   private void processOutboundMessage( String outboundMessage ) {
     try {
-      this.session.getRemote().sendString( outboundMessage );
+      this.session.sendText( outboundMessage, Callback.NOOP );
     } catch ( Exception e ) {
       logger.error( "Error sending message. Closing websocket...", e );
       processErrorMessage( "Error while sending message." );
@@ -74,7 +75,7 @@ public class CdaJettyWebsocket {
         // The server is terminating the connection because
         // it encountered an unexpected condition that prevented it from
         // fulfilling the request.
-        this.session.close( 1011, errorMessage );
+        this.session.close( 1011, errorMessage, Callback.NOOP );
       }
     } catch ( Exception e ) {
       logger.error( "Error closing socket, with message " + errorMessage, e );

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
@@ -12,9 +12,9 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class CdaJettyWebsocketTest {
     this.websocket = new CdaJettyWebsocket( this.mockRequest, this.mockPlatformWebsocketEndpoint );
   }
 
-  @OnWebSocketConnect
+  @OnWebSocketOpen
   public void onConnect( Session session ) {
     this.websocket.onConnect( session );
 
@@ -70,12 +70,10 @@ public class CdaJettyWebsocketTest {
     } ).when( this.mockPlatformWebsocketEndpoint ).onOpen( any( Consumer.class ) );
 
     Session mockSession = mock( Session.class );
-    RemoteEndpoint mockRemote = mock( RemoteEndpoint.class );
-    when(mockSession.getRemote()).thenReturn( mockRemote );
     this.websocket.onConnect( mockSession );
 
-    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_1 );
-    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_2 );
+    verify( mockSession, times( 1 ) ).sendText( OUTBOUND_MESSAGE_1 , Callback.NOOP);
+    verify( mockSession, times( 1 ) ).sendText( OUTBOUND_MESSAGE_2 , Callback.NOOP );
   }
 
   @Test


### PR DESCRIPTION
[BACKLOG-42885]-Upgrading Jetty version from 11.0.14 to 12.0.15 to support Jakarta EE 10

[BACKLOG-42885]: https://hv-eng.atlassian.net/browse/BACKLOG-42885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ