### PR TITLE
fix[PPP-5720]: remove instances of unsafe deserialization by readObject

### DIFF
--- a/core/src/main/java/pt/webdetails/cda/cache/CacheKey.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/CacheKey.java
@@ -18,12 +18,13 @@ import org.apache.commons.lang.StringUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class CacheKey implements Serializable {
 
   private static final long serialVersionUID = -1273843592305584696L;
 
-  private ArrayList<KeyValuePair> keyValuePairs = new ArrayList<KeyValuePair>();
+  private ArrayList<KeyValuePair> keyValuePairs = new ArrayList<>();
 
   public CacheKey() {
   }
@@ -34,7 +35,7 @@ public class CacheKey implements Serializable {
 
   public ArrayList<KeyValuePair> getKeyValuePairs() {
     if ( keyValuePairs == null ) {
-      keyValuePairs = new ArrayList<KeyValuePair>();
+      keyValuePairs = new ArrayList<>();
     }
     return keyValuePairs;
   }
@@ -47,11 +48,7 @@ public class CacheKey implements Serializable {
 
   public void removeByKey( String key ) {
     if ( !StringUtils.isEmpty( key ) ) {
-      for ( KeyValuePair pair : getKeyValuePairs() ) {
-        if ( key.equals( pair.getKey() ) ) {
-          getKeyValuePairs().remove( pair );
-        }
-      }
+      getKeyValuePairs().removeIf( pair -> key.equals( pair.getKey() ) );
     }
   }
 
@@ -77,11 +74,7 @@ public class CacheKey implements Serializable {
 
     final CacheKey other = (CacheKey) o;
 
-    if ( keyValuePairs != null ? !keyValuePairs.equals( other.keyValuePairs ) : other.keyValuePairs != null ) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals( keyValuePairs, other.keyValuePairs );
   }
 
   @Override
@@ -155,15 +148,7 @@ public class CacheKey implements Serializable {
 
       final KeyValuePair other = (KeyValuePair) o;
 
-      if ( this.key == null ? other.key != null : !this.key.equals( other.key ) ) {
-        return false;
-      }
-
-      if ( this.value == null ? other.value != null : !this.value.equals( other.value ) ) {
-        return false;
-      }
-
-      return true;
+      return Objects.equals( this.key, other.key ) && Objects.equals( this.value, other.value );
     }
 
     @Override
@@ -180,13 +165,13 @@ public class CacheKey implements Serializable {
         + "]\n";
     }
 
-  /*
-   * Serializable classes that require special handling during the serialization and deserialization process should
-   * implement the following methods: writeObject(java.io.ObjectOutputStream stream),
-   * readObject(java.io.ObjectInputStream stream)
-   *
-   * @see http://docs.oracle.com/javase/6/docs/api/java/io/ObjectInputStream.html
-   */
+    /*
+     * Serializable classes that require special handling during the serialization and deserialization process should
+     * implement the following methods: writeObject(java.io.ObjectOutputStream stream),
+     * readObject(java.io.ObjectInputStream stream)
+     *
+     * @see http://docs.oracle.com/javase/6/docs/api/java/io/ObjectInputStream.html
+     */
 
     private void readObject( java.io.ObjectInputStream in ) throws IOException, ClassNotFoundException {
       key = (String) in.readObject();

--- a/core/src/main/java/pt/webdetails/cda/cache/CacheKey.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/CacheKey.java
@@ -174,13 +174,13 @@ public class CacheKey implements Serializable {
      */
 
     private void readObject( java.io.ObjectInputStream in ) throws IOException, ClassNotFoundException {
-      key = (String) in.readObject();
-      value = (String) in.readObject();
+      key = in.readUTF();
+      value = in.readUTF();
     }
 
     private void writeObject( java.io.ObjectOutputStream out ) throws IOException {
-      out.writeObject( key );
-      out.writeObject( value );
+      out.writeUTF( key );
+      out.writeUTF( value );
     }
   }
 }

--- a/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
@@ -171,7 +171,7 @@ public class EHCacheQueryCache implements IQueryCache {
       Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
       final Element element = cache.get( key );
       if ( element != null ) {
-        final TableModel cachedTableModel = (TableModel) ( (CacheElement) element.getObjectValue() ).getTable();
+        final TableModel cachedTableModel = ( (CacheElement) element.getObjectValue() ).getTable();
         if ( cachedTableModel != null ) {
           if ( logger.isDebugEnabled() ) {
             // we have a entry in the cache ... great!

--- a/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
@@ -67,7 +67,11 @@ public class EHCacheQueryCache implements IQueryCache {
     }
 
     private void writeObject( ObjectOutputStream out ) throws IOException {
-      out.writeObject( table );
+      if ( table instanceof Serializable ) {
+        out.writeObject( table );
+      } else {
+        throw new IOException("Cannot call writeObject on TableModel (object is not serializable)");
+      }
       out.writeObject( info );
     }
 
@@ -112,7 +116,12 @@ public class EHCacheQueryCache implements IQueryCache {
       }
     }
 
-    if ( cacheManager.cacheExists( CACHE_NAME ) == false ) {
+    if ( cacheManager == null ) {
+      logger.error( "Cache manager is null" );
+      return null;
+    }
+
+    if ( !cacheManager.cacheExists( CACHE_NAME ) ) {
       cacheManager.addCache( CACHE_NAME );
     }
 

--- a/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
@@ -200,12 +200,14 @@ public class TableCacheKey implements Serializable {
     throws IOException, ClassNotFoundException {
     ByteArrayInputStream keyStream = new ByteArrayInputStream( Base64.decodeBase64( encodedCacheKey.getBytes() ) );
 
-    // We add this filter allow only Parameter, Type and CacheKey, and block everything else from readObject.
-    // This is important because readObject can allow injection attacks.
+    // We add this filter to allow only the specific classes that will be read further ahead,
+    // and block everything else from readObject. This is important because readObject can allow injection attacks.
     ObjectInputFilter paramFilter = ObjectInputFilter.Config.createFilter(
       "pt.webdetails.cda.dataaccess.Parameter;"
         + "pt.webdetails.cda.dataaccess.Parameter$Type;"
         + "pt.webdetails.cda.cache.CacheKey;"
+        + "javax.swing.table.TableModel;"
+        + "pt.webdetails.cda.cache.monitor.ExtraCacheInfo;"
         + "!*"
     );
     ObjectInputStream objStream = new FilteredObjectInputStream( keyStream, paramFilter );

--- a/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
@@ -208,6 +208,7 @@ public class TableCacheKey implements Serializable {
         + "pt.webdetails.cda.cache.CacheKey;"
         + "javax.swing.table.TableModel;"
         + "pt.webdetails.cda.cache.monitor.ExtraCacheInfo;"
+        + "pt.webdetails.cda.dataaccess.MdxDataAccess$BANDED_MODE;"
         + "!*"
     );
     ObjectInputStream objStream = new FilteredObjectInputStream( keyStream, paramFilter );

--- a/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/TableCacheKey.java
@@ -26,11 +26,12 @@ import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 public class TableCacheKey implements Serializable {
 
@@ -193,12 +194,11 @@ public class TableCacheKey implements Serializable {
    * Serialize as printable <code>String</code>.
    */
   public static String getTableCacheKeyAsString( TableCacheKey cacheKey )
-    throws IOException, UnsupportedEncodingException {
+    throws IOException {
     ByteArrayOutputStream keyStream = new ByteArrayOutputStream();
     ObjectOutputStream objStream = new ObjectOutputStream( keyStream );
     cacheKey.writeObject( objStream );
-    String identifier = new String( Base64.encodeBase64( keyStream.toByteArray() ), "UTF-8" );
-    return identifier;
+    return new String( Base64.encodeBase64( keyStream.toByteArray() ), StandardCharsets.UTF_8 );
   }
 
   /**
@@ -229,14 +229,10 @@ public class TableCacheKey implements Serializable {
     if ( parameters != null ? !Arrays.equals( parameters, that.parameters ) : that.parameters != null ) {
       return false;
     }
-    if ( query != null ? !query.equals( that.query ) : that.query != null ) {
+    if ( !Objects.equals( query, that.query ) ) {
       return false;
     }
-    if ( extraCacheKey != null ? !extraCacheKey.equals( that.extraCacheKey ) : that.extraCacheKey != null ) {
-      return false;
-    }
-
-    return true;
+    return Objects.equals( extraCacheKey, that.extraCacheKey );
   }
 
 
@@ -273,11 +269,11 @@ public class TableCacheKey implements Serializable {
    * for serialization
    */
   private static Parameter[] createParametersFromParameterDataRow( final ParameterDataRow row ) {
-    ArrayList<Parameter> parameters = new ArrayList<Parameter>();
+    ArrayList<Parameter> parameters = new ArrayList<>();
     if ( row != null ) {
       for ( String name : row.getColumnNames() ) {
         Object value = row.get( name );
-        Parameter param = new Parameter( name, value != null ? value : null );
+        Parameter param = new Parameter( name, value );
         Parameter.Type type = Parameter.Type.inferTypeFromObject( value );
         param.setType( type );
         parameters.add( param );

--- a/core/src/main/java/pt/webdetails/cda/cache/monitor/ExtraCacheInfo.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/monitor/ExtraCacheInfo.java
@@ -116,25 +116,25 @@ public class ExtraCacheInfo implements Serializable {
   }
 
   private void writeObject( ObjectOutputStream out ) throws IOException {
-    out.writeObject( cdaSettingsId );
-    out.writeObject( dataAccessId );
+    out.writeUTF( cdaSettingsId );
+    out.writeUTF( dataAccessId );
     out.writeLong( queryDurationMs );
     out.writeInt( nbrRows );
     out.writeLong( entryTime );
     out.writeInt( timeToLive );
-    out.writeObject( tableSnapshot != null ? tableSnapshot.toString() : null );
+    out.writeUTF( tableSnapshot != null ? tableSnapshot.toString() : null );
   }
 
   private void readObject( ObjectInputStream in ) throws IOException, ClassNotFoundException {
-    cdaSettingsId = (String) in.readObject();
-    dataAccessId = (String) in.readObject();
+    cdaSettingsId = in.readUTF();
+    dataAccessId = in.readUTF();
     queryDurationMs = in.readLong();
     nbrRows = in.readInt();
     entryTime = in.readLong();
     timeToLive = in.readInt();
 
     try {
-      tableSnapshot = new JSONObject( (String) in.readObject() );
+      tableSnapshot = new JSONObject( in.readUTF() );
     } catch ( Exception e ) {
       tableSnapshot = null;
     }

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/AbstractDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/AbstractDataAccess.java
@@ -36,7 +36,6 @@ import pt.webdetails.cda.utils.Util;
 import pt.webdetails.cda.utils.kettle.SortException;
 
 import javax.swing.table.TableModel;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -232,7 +231,7 @@ public abstract class AbstractDataAccess implements DataAccess {
 
   public static synchronized void clearCache() {
     IQueryCache cache = getCdaCache();
-    cache.clearCache();
+      cache.clearCache();
   }
 
 
@@ -666,7 +665,7 @@ public abstract class AbstractDataAccess implements DataAccess {
     return columnDefinitions;
   }
 
-  public Serializable getCacheKey() {
+  public CacheKey getCacheKey() {
     String cacheKeyInfo =
       "Getting Cache Key for file: " + this.getCdaSettings().getId() + ", DataAccessID: " + this.getId() + "\n";
     CacheKey systemWideCacheKey = getSystemCacheKeys();
@@ -720,7 +719,7 @@ public abstract class AbstractDataAccess implements DataAccess {
    *
    * @return
    */
-  protected Serializable getExtraCacheKey() {
+  protected CacheKey getExtraCacheKey() {
     return getCacheKey();
   }
 }

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
@@ -48,7 +48,7 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
   }
 
   @Override
-  protected Serializable getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
+  protected CacheKey getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
     // .evaluate()?
     MondrianConnectionInfo mci;
     try {
@@ -58,7 +58,7 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
       mci = null;
     }
 
-    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+    CacheKey cacheKey = getCacheKey() != null ? ( getCacheKey() ).clone() : new CacheKey();
 
     cacheKey.addKeyValuePair( "roles", mci.getMondrianRole() );
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
@@ -40,6 +40,7 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
   public DenormalizedMdxDataAccess() {
   }
 
+  @Override
   protected AbstractNamedMDXDataFactory createDataFactory() {
     return new ExtDenormalizedMDXDataFactory();
   }
@@ -61,8 +62,11 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
 
     CacheKey cacheKey = getCacheKey() != null ? ( getCacheKey() ).clone() : new CacheKey();
 
-    cacheKey.addKeyValuePair( "roles", mci.getMondrianRole() );
-
+    if ( mci != null) {
+      cacheKey.addKeyValuePair( "roles", mci.getMondrianRole() );
+    } else {
+      logger.warn( "No Mondrian connection info was found for cache key, roles were not included." );
+    }
     return cacheKey;
   }
 
@@ -91,12 +95,12 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
 
 
     private void readObject( java.io.ObjectInputStream in ) throws IOException, ClassNotFoundException {
-      this.roles = (String) in.readObject();
+      this.roles = in.readUTF();
     }
 
 
     private void writeObject( java.io.ObjectOutputStream out ) throws IOException {
-      out.writeObject( this.roles );
+      out.writeUTF( this.roles );
     }
 
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/DenormalizedMdxDataAccess.java
@@ -24,6 +24,7 @@ import pt.webdetails.cda.utils.mondrian.ExtDenormalizedMDXDataFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Implementation of a DataAccess that will get data from a SQL database
@@ -48,7 +49,7 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
   }
 
   @Override
-  protected CacheKey getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
+  protected CacheKey getExtraCacheKey() {
     // .evaluate()?
     MondrianConnectionInfo mci;
     try {
@@ -85,10 +86,7 @@ public class DenormalizedMdxDataAccess extends GlobalMdxDataAccess {
       }
       final ExtraCacheKey other = (ExtraCacheKey) obj;
 
-      if ( this.roles == null ? other.roles != null : !this.roles.equals( other.roles ) ) {
-        return false;
-      }
-      return true;
+      return Objects.equals( this.roles, other.roles );
     }
 
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/KettleDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/KettleDataAccess.java
@@ -115,7 +115,7 @@ public class KettleDataAccess extends PREDataAccess {
 
   @Override
   protected IDataSourceQuery performRawQuery( ParameterDataRow parameterDataRow ) throws QueryException {
-    if ( getParameters().size() == 0 ) {
+    if ( getParameters().isEmpty() ) {
       return super.performRawQuery( parameterDataRow );
     }
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/KettleDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/KettleDataAccess.java
@@ -32,7 +32,6 @@ import pt.webdetails.cda.settings.CdaSettings;
 import pt.webdetails.cda.settings.UnknownConnectionException;
 import pt.webdetails.cda.utils.ParameterArrayToStringEncoder;
 
-import java.io.Serializable;
 import java.util.List;
 
 public class KettleDataAccess extends PREDataAccess {
@@ -88,9 +87,9 @@ public class KettleDataAccess extends PREDataAccess {
    * paths, only the path needs to be stored.
    */
   @Override
-  public Serializable getExtraCacheKey() {
+  public CacheKey getExtraCacheKey() {
 
-    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+    CacheKey cacheKey = getCacheKey() != null ? ( getCacheKey() ).clone() : new CacheKey();
 
     cacheKey.addKeyValuePair( "path", path );
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
@@ -27,6 +27,7 @@ import pt.webdetails.cda.utils.mondrian.ExtBandedMDXDataFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Implementation of a DataAccess that will get data from a SQL database
@@ -116,7 +117,7 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
 
 
   @Override
-  protected CacheKey getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
+  protected CacheKey getExtraCacheKey() {
     // .evaluate()?
     MondrianConnectionInfo mci;
     try {
@@ -159,13 +160,7 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
         return false;
       }
       final ExtraCacheKey other = (ExtraCacheKey) obj;
-      if ( this.bandedMode != other.bandedMode && ( this.bandedMode == null || !this.bandedMode
-        .equals( other.bandedMode ) ) ) {
-        return false;
-      } else if ( this.roles == null ? other.roles != null : !this.roles.equals( other.roles ) ) {
-        return false;
-      }
-      return true;
+      return Objects.equals( this.bandedMode, other.bandedMode ) && Objects.equals( this.roles, other.roles );
     }
 
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
@@ -116,7 +116,7 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
 
 
   @Override
-  protected Serializable getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
+  protected CacheKey getExtraCacheKey() { //TODO: is this necessary after role assembly in EvaluableConnection
     // .evaluate()?
     MondrianConnectionInfo mci;
     try {

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/MdxDataAccess.java
@@ -127,7 +127,7 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
       mci = null;
     }
 
-    CacheKey cacheKey = getCacheKey() != null ? ( (CacheKey) getCacheKey() ).clone() : new CacheKey();
+    CacheKey cacheKey = getCacheKey() != null ? ( getCacheKey() ).clone() : new CacheKey();
 
     cacheKey.addKeyValuePair( "bandedMode", bandedMode.toString() );
     if ( mci != null ) {
@@ -166,13 +166,13 @@ public class MdxDataAccess extends GlobalMdxDataAccess {
 
     private void readObject( java.io.ObjectInputStream in ) throws IOException, ClassNotFoundException {
       this.bandedMode = (BANDED_MODE) in.readObject();
-      this.roles = (String) in.readObject();
+      this.roles = in.readUTF();
     }
 
 
     private void writeObject( java.io.ObjectOutputStream out ) throws IOException {
       out.writeObject( this.bandedMode );
-      out.writeObject( this.roles );
+      out.writeUTF( this.roles );
     }
 
 

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/Parameter.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/Parameter.java
@@ -14,7 +14,6 @@
 package pt.webdetails.cda.dataaccess;
 
 import java.io.IOException;
-import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.text.ParseException;
@@ -112,8 +111,8 @@ public class Parameter implements java.io.Serializable {
   public static ParameterDataRow createParameterDataRowFromParameters( final Parameter[] parameters )
     throws InvalidParameterException {
 
-    final ArrayList<String> names = new ArrayList<String>();
-    final ArrayList<Object> values = new ArrayList<Object>();
+    final ArrayList<String> names = new ArrayList<>();
+    final ArrayList<Object> values = new ArrayList<>();
 
     if ( parameters != null ) {
       for ( final Parameter parameter : parameters ) {
@@ -122,10 +121,7 @@ public class Parameter implements java.io.Serializable {
       }
     }
 
-    final ParameterDataRow parameterDataRow =
-      new ParameterDataRow( names.toArray( new String[] {} ), values.toArray() );
-
-    return parameterDataRow;
+    return new ParameterDataRow( names.toArray( new String[] {} ), values.toArray() );
   }
 
   public void inheritDefaults( Parameter defaultParameter ) {
@@ -162,31 +158,34 @@ public class Parameter implements java.io.Serializable {
       */
     }
 
-    if ( objValue instanceof String ) { //may be a string or a parsed value
-      final String strValue = (String) objValue;
-      //check if it is a formula
-      if ( strValue != null && strValue.trim().startsWith( FORMULA_BEGIN ) ) {
-        String formula = Util.getContentsBetween( strValue, FORMULA_BEGIN, FORMULA_END );
-        if ( formula == null ) {
-          throw new InvalidParameterException( "Malformed formula expression", null );
-        }
-        Object value = FormulaEvaluator.processFormula( formula );
-        if ( getType() == Type.STRING && !( value instanceof String ) ) {
-          return getValueAsString( value );
-        } else {
-          return value;
-        }
-      }
-
-      Type valueType = getType();
-      if ( valueType == null ) {
-        throw new InvalidParameterException( "Parameter type " + getType() + " unknown, can't continue", null );
-      }
-      value = getValueFromString( strValue, valueType );
-      return value;
+    if ( objValue instanceof String ) {
+      return handleStringValue( (String) objValue ); //may be a string or a parsed value
     } else {
       return objValue;
     }
+  }
+
+  private Object handleStringValue( String strValue ) throws InvalidParameterException {
+    //check if it is a formula
+    if ( strValue.trim().startsWith( FORMULA_BEGIN ) ) {
+      String formula = Util.getContentsBetween( strValue, FORMULA_BEGIN, FORMULA_END );
+      if ( formula == null ) {
+        throw new InvalidParameterException( "Malformed formula expression", null );
+      }
+      Object evaluatedValue = FormulaEvaluator.processFormula( formula );
+      if ( getType() == Type.STRING && !( evaluatedValue instanceof String ) ) {
+        return getValueAsString( evaluatedValue );
+      } else {
+        return evaluatedValue;
+      }
+    }
+
+    Type valueType = getType();
+    if ( valueType == null ) {
+      throw new InvalidParameterException( "Parameter type " + getType() + " unknown, can't continue", null );
+    }
+    value = getValueFromString( strValue, valueType );
+    return value;
   }
 
   public void setValue( final Object value ) {
@@ -201,7 +200,7 @@ public class Parameter implements java.io.Serializable {
    */
   private Object getValueFromString( final String localValue, Type valueType ) throws InvalidParameterException {
 
-    switch( valueType ) {
+    switch ( valueType ) {
       case STRING:
         return localValue;
       case INTEGER:
@@ -237,7 +236,7 @@ public class Parameter implements java.io.Serializable {
   private <T> T[] parseToArray( String arrayAsString, Type elementType, T[] array ) throws InvalidParameterException {
     CSVTokenizer tokenizer = new CSVTokenizer( arrayAsString, getSeparator() );
 
-    ArrayList<T> result = new ArrayList<T>();
+    ArrayList<T> result = new ArrayList<>();
     while ( tokenizer.hasMoreTokens() ) {
       result.add( (T) getValueFromString( tokenizer.nextToken(), elementType ) );
     }
@@ -285,9 +284,7 @@ public class Parameter implements java.io.Serializable {
   }
 
   private String getValueAsString( Object value ) {
-    String separator = getSeparator();
-
-    ParameterArrayToStringEncoder encoder = new ParameterArrayToStringEncoder( separator, getQuoteCharacter() );
+    ParameterArrayToStringEncoder encoder = new ParameterArrayToStringEncoder( getSeparator(), getQuoteCharacter() );
     if ( value == null ) {
       if ( getDefaultValue() != null ) {
         return getDefaultValue().toString();
@@ -297,7 +294,7 @@ public class Parameter implements java.io.Serializable {
     } else if ( value instanceof String ) {
       return (String) value;
     } else if ( type != null ) {
-      switch( type ) {
+      switch ( type ) {
         case STRING_ARRAY://csvTokenizer compatible
           return encoder.encodeParameterArray( value, type );
         case DATE:
@@ -413,7 +410,7 @@ public class Parameter implements java.io.Serializable {
       ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(
         "pt.webdetails.cda.dataaccess.Parameter$Type;!*"
       );
-      in.setObjectInputFilter(filter);
+      in.setObjectInputFilter( filter );
       this.setStringValue( in.readUTF(), this.getType() );
 
       this.setSeparator( in.readUTF() );
@@ -458,6 +455,7 @@ public class Parameter implements java.io.Serializable {
       return PUBLIC; //default
     }
 
+    @Override
     public String toString() {
       return this.name;
     }
@@ -523,7 +521,7 @@ public class Parameter implements java.io.Serializable {
     }
 
     public boolean isArrayType() {
-      switch( this ) {
+      switch ( this ) {
         case STRING_ARRAY:
         case INTEGER_ARRAY:
         case NUMERIC_ARRAY:

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/Parameter.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/Parameter.java
@@ -405,12 +405,6 @@ public class Parameter implements java.io.Serializable {
       this.setName( in.readUTF() );
       this.setType( (Type) in.readObject() );
 
-      // We add this filter allow only Type and block everything else from readObject.
-      // This is important because readObject can allow injection attacks.
-      ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(
-        "pt.webdetails.cda.dataaccess.Parameter$Type;!*"
-      );
-      in.setObjectInputFilter( filter );
       this.setStringValue( in.readUTF(), this.getType() );
 
       this.setSeparator( in.readUTF() );

--- a/core/src/main/java/pt/webdetails/cda/dataaccess/SimpleDataAccess.java
+++ b/core/src/main/java/pt/webdetails/cda/dataaccess/SimpleDataAccess.java
@@ -190,7 +190,7 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
     // Get parameters from definition and apply their values
     //TODO: use queryOptions' parameters instead of copying?
-    final List<Parameter> parameters = new ArrayList<Parameter>( getParameters().size() );
+    final List<Parameter> parameters = new ArrayList<>( getParameters().size() );
     for ( Parameter param : getParameters() ) {
       parameters.add( new Parameter( param ) );
     }
@@ -253,7 +253,7 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
       //log query and duration
       String logMsg = "Query " + queryId + " took " + duration + "s.\n";
       logMsg += "\t Query contents: << " + query.trim() + " >>\n";
-      if ( parameters.size() > 0 ) {
+      if ( !parameters.isEmpty() ) {
         logMsg += "\t Parameters: \n";
         for ( Parameter parameter : parameters ) {
           logMsg += "\t\t" + parameter.toString() + "\n";
@@ -272,7 +272,7 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
   /**
    * Logs that the query is starting.
-   *
+   * <p>
    * Used for correlating query and parameters with other MDC logging information.
    *
    * @param queryOptions The query options.
@@ -282,20 +282,20 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
     if ( logger.isDebugEnabled() ) {
       StringBuilder logMsgBuilder = new StringBuilder( String.format(
-              "QUERY START path: \"%s\" dataAccessId: \"%s\" dataAccessName: \"%s\" "
-                + "dataAccessType: \"%s\" outputIndex: \"%d\"",
-              this.getCdaSettings().getId(),
-              getId(),
-              getName(),
-              getType(),
-              queryOptions.getOutputIndexId() ) );
+        "QUERY START path: \"%s\" dataAccessId: \"%s\" dataAccessName: \"%s\" "
+          + "dataAccessType: \"%s\" outputIndex: \"%d\"",
+        this.getCdaSettings().getId(),
+        getId(),
+        getName(),
+        getType(),
+        queryOptions.getOutputIndexId() ) );
 
       String logQuery = getLogQuery();
       if ( logQuery != null ) {
         String queryText = Arrays.stream( logQuery.trim().split( "\r|\n|\r\n" ) )
-                .map( String::trim )
-                .collect( Collectors.joining( "%n\t\t" ) );
-        if ( queryText.length() > 0  ) {
+          .map( String::trim )
+          .collect( Collectors.joining( "%n\t\t" ) );
+        if ( !queryText.isEmpty() ) {
           logMsgBuilder.append( String.format( "%n\t Query:%n\t\t===%n\t\t%s%n\t\t===", queryText ) );
         }
       }
@@ -331,7 +331,6 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
     public void closeDataSource() throws QueryException;
   }
-
 
   protected abstract IDataSourceQuery performRawQuery( ParameterDataRow parameterDataRow ) throws QueryException;
 
@@ -382,7 +381,7 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
 
   public void accept( DomVisitor xmlVisitor, Element root ) {
-    xmlVisitor.visit( (SimpleDataAccess) this, root );
+    xmlVisitor.visit( this, root );
   }
 
 
@@ -396,18 +395,19 @@ public abstract class SimpleDataAccess extends AbstractDataAccess implements Dom
 
   /**
    * Parses the text content of an xml node defensively.
-   * @param element base node
-   * @param nodePath path from {@code element}
-   * @param parse convert string to value
+   *
+   * @param element      base node
+   * @param nodePath     path from {@code element}
+   * @param parse        convert string to value
    * @param defaultValue default value in case of not found, empty or error
    * @return
    */
   protected <T> T parseNode( Element element, String nodePath, Function<String, T> parse, T defaultValue ) {
     try {
       return Optional.ofNullable( element.selectSingleNode( nodePath ) )
-          .map( Node::getText )
-          .map( parse )
-          .orElse( defaultValue );
+        .map( Node::getText )
+        .map( parse )
+        .orElse( defaultValue );
     } catch ( Exception e ) {
       logger.error( " parse error in " + this.getName() + ": " + e.getMessage() );
       return defaultValue;


### PR DESCRIPTION
My main changes involve 3 different fixes for these insecure uses of `readObject`:
- when the object was a String, I replaced `writeObject` and `readObject` with `writeUTF` and `readUTF`;

- when the object was a custom type, I added it to an ObjectInputFilter, which is passed into the `ObjectInputStream`, to only allow those types:
  - I had to create a custom filter class because `ObjectInputStream` does some stream header reading on its constructor, and you can only set an `ObjectInputFilter` when the stream has not read anything, so I had to do it via this custom class, as the filter could not be set after class instantiation;
  
- for `extraCacheKey` I could not add it to the filter _as is_, because the object was a `Serializable`, and if I allow the `ObjectInputStream` to accept `Serializable` objects, the danger of injection attacks still remains. However I saw that `extraCacheKey` was just a `CacheKey` object that was being unnecessarily converted (or "extended") to its parent type `Serializable`, so I just made it "remain" as a `CacheKey` through the whole process and then filtered that custom type, similarly to the ones on the above step.

I also addressed (in a separate commit) some of the SonarQube changes suggested for the files I altered (and some other files that I had altered but ended up not altering), but I wasn't super thorough and basically only did the changes which I believed would not cause problems elsewhere.