### PR TITLE
feat[SP-6856]: upgrade commons-io

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,6 @@
   </licenses>
   <properties>
     <dependency.poi.revision>3.12</dependency.poi.revision>
-    <dependency.commons-io.revision>2.1</dependency.commons-io.revision>
     <commons-lang.version>2.6</commons-lang.version>
     <dependency.xmlunit.revision>1.3</dependency.xmlunit.revision>
     <dependency.hsqldb.revision>2.3.2</dependency.hsqldb.revision>
@@ -119,7 +118,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>${dependency.commons-io.revision}</version>
+      <version>${commons-io.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>


### PR DESCRIPTION
Removed several hard-coded versions - use what comes from parent pom

(cherry picked from commit 564adccf9c663ceaff8b8787a955a2710796353c)
Original PR: [cda#432](https://github.com/webdetails/cda/pull/432)

