### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/assemblies/cda-foundry/src/main/resources-filtered/data-integration/system/karaf/etc/custom.properties
+++ b/assemblies/cda-foundry/src/main/resources-filtered/data-integration/system/karaf/etc/custom.properties
@@ -121,10 +121,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.database.*, \
  com.thoughtworks.xstream;version\="1.4.9", \
  com.thoughtworks.xstream.*;version\="1.4.9", \
- com.sun.jersey.api.client;version\="1.19.1", \
- com.sun.jersey.api.client.*;version\="1.19.1", \
- com.sun.jersey.core.header;version\="1.19.1", \
- com.sun.jersey.multipart;version\="1.19.1", \
+ org.glassfish.jersey.*;version="2.44",\
  javax.ws.rs.*;version\="1.1.1", \
  org.dom4j.*, \
  org.dom4j, \

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,6 @@
     <dependency.hsqldb.revision>2.3.2</dependency.hsqldb.revision>
     <dependency.bsh.revision>1.3.0</dependency.bsh.revision>
     <dependency.bsf.revision>2.4.0</dependency.bsf.revision>
-    <dependency.ehcache-core.revision>2.5.1</dependency.ehcache-core.revision>
     <dependency.jxl.revision>2.6.12</dependency.jxl.revision>
     <dependency.jsr311-api.revision>1.1-ea</dependency.jsr311-api.revision>
     <owasp.encoder.version>1.2</owasp.encoder.version>
@@ -141,6 +140,7 @@
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
       <version>${ehcache-core.version}</version>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>javax.cache</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,9 +138,14 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-core</artifactId>
-      <version>${dependency.ehcache-core.revision}</version>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${ehcache-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${cache-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.hazelcast</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -203,8 +203,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -231,8 +231,8 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <!-- TEST -->

--- a/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
+++ b/core/src/main/java/pt/webdetails/cda/cache/EHCacheQueryCache.java
@@ -19,14 +19,16 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.MutableConfiguration;
 import javax.swing.table.TableModel;
 
 import mondrian.olap.InvalidArgumentException;
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheException;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
-import net.sf.ehcache.Status;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -43,6 +45,7 @@ public class EHCacheQueryCache implements IQueryCache {
   private static final String CACHE_NAME = "pentaho-cda-dataaccess";
   private static final String CACHE_CFG_FILE = "ehcache-cda.xml";
   private static final String CACHE_CFG_FILE_DIST = "ehcache-dist.xml";
+  private static final String ENABLE_SHUTDOWN_HOOK_PROPERTY = "javax.cache.CacheManager.enableShutdownHook";
   private static final String USE_TERRACOTTA_PROPERTY = "pt.webdetails.cda.UseTerracotta";
   private static CacheManager cacheManager;
 
@@ -97,7 +100,7 @@ public class EHCacheQueryCache implements IQueryCache {
         InputStream configFile = null;
         try {
           configFile = CdaEngine.getRepo().getPluginSystemReader( "" ).getFileInputStream( configFilePath );
-          cacheManager = new CacheManager( configFile );
+          cacheManager = Caching.getCachingProvider().getCacheManager();
           logger.debug( "Cache started using " + configFilePath );
         } catch ( IOException ioe ) {
           logger.error( "Error reading " + configFilePath );
@@ -121,8 +124,10 @@ public class EHCacheQueryCache implements IQueryCache {
       return null;
     }
 
-    if ( !cacheManager.cacheExists( CACHE_NAME ) ) {
-      cacheManager.addCache( CACHE_NAME );
+    if ( cacheManager.getCache( CACHE_NAME ) == null ) {
+      MutableConfiguration<Object,Object> configuration =
+        new MutableConfiguration<>().setStoreByValue( false );
+      cacheManager.createCache( CACHE_NAME , configuration );
     }
 
     return cacheManager.getCache( CACHE_NAME );
@@ -131,7 +136,7 @@ public class EHCacheQueryCache implements IQueryCache {
   private static void enableCacheProperShutdown( final boolean force ) {
     if ( !force ) {
       try {
-        System.getProperty( CacheManager.ENABLE_SHUTDOWN_HOOK_PROPERTY );
+        System.getProperty( ENABLE_SHUTDOWN_HOOK_PROPERTY );
         return; // unless force, ignore if already set
       } catch ( NullPointerException npe ) {
         // key null, continue
@@ -142,7 +147,7 @@ public class EHCacheQueryCache implements IQueryCache {
         return;
       }
     }
-    System.setProperty( CacheManager.ENABLE_SHUTDOWN_HOOK_PROPERTY, "true" );
+    System.setProperty( ENABLE_SHUTDOWN_HOOK_PROPERTY, "true" );
   }
 
   Cache cache = null;
@@ -161,14 +166,7 @@ public class EHCacheQueryCache implements IQueryCache {
 
   public void putTableModel( TableCacheKey key, TableModel table, int ttlSec, ExtraCacheInfo info ) {
     final CacheElement cacheElement = new CacheElement( table, info );
-    final Element storeElement = new Element( key, cacheElement );
-    storeElement.setTimeToLive( ttlSec );
-    cache.put( storeElement );
-    cache.flush();
-
-    // Print cache status size
-    logger.debug( "Cache status: " + cache.getMemoryStoreSize() + " in memory, "
-      + cache.getDiskStoreSize() + " in disk" );
+    cache.put( key, cacheElement );
   }
 
   @Override
@@ -178,16 +176,13 @@ public class EHCacheQueryCache implements IQueryCache {
       //make sure we have the right class loader in thread to instantiate cda classes in case DiskStore is used
       //TODO: ehcache 2.5 has ClassLoaderAwareCache
       Thread.currentThread().setContextClassLoader( this.getClass().getClassLoader() );
-      final Element element = cache.get( key );
+      final Object element = cache.get( key );
       if ( element != null ) {
-        final TableModel cachedTableModel = ( (CacheElement) element.getObjectValue() ).getTable();
+        final TableModel cachedTableModel = (TableModel) ( (CacheElement) element ).getTable();
         if ( cachedTableModel != null ) {
           if ( logger.isDebugEnabled() ) {
             // we have a entry in the cache ... great!
             logger.debug( "Found tableModel in cache. Returning" );
-            // Print cache status size
-            logger.debug( "Cache status: " + cache.getMemoryStoreSize() + " in memory, "
-              + cache.getDiskStoreSize() + " in disk" );
           }
           return cachedTableModel;
         }
@@ -218,18 +213,20 @@ public class EHCacheQueryCache implements IQueryCache {
   @SuppressWarnings( "unchecked" )
   @Override
   public Iterable<TableCacheKey> getKeys() {
-    return cache.getKeys();
+    List<TableCacheKey> keys = new ArrayList<>();
+    cache.iterator().forEachRemaining(entry -> keys.add(((javax.cache.Cache.Entry<TableCacheKey,?>) entry).getKey()));
+    return keys;
   }
 
   @Override
   public ExtraCacheInfo getCacheEntryInfo( TableCacheKey key ) {
-    Element element = cache.getQuiet( key );
+    Object element = cache.get( key );
     if ( element == null ) {
       logger.warn( "Null element in cache, removing." );
       remove( key );
       return null;
     }
-    Object val = element.getValue();
+    Object val = element;
     if ( val instanceof CacheElement ) {
       return ( (CacheElement) val ).getInfo();
     } else {
@@ -243,15 +240,12 @@ public class EHCacheQueryCache implements IQueryCache {
   @Override
   public CacheElementInfo getElementInfo( TableCacheKey key ) {
 
-    Element element = cache.getQuiet( key );
+    Object element = cache.get( key );
     CacheElementInfo info = new CacheElementInfo();
     info.setKey( key );
     if ( element != null ) {
 
-      info.setInsertTime( element.getLatestOfCreationAndUpdateTime() );
-      info.setAccessTime( element.getLastAccessTime() );
-      info.setHits( element.getHitCount() );
-      Object val = element.getValue();
+      Object val = element;
       if ( val instanceof CacheElement ) {
         info.setRows( ( (CacheElement) val ).getTable().getRowCount() );
       }
@@ -264,12 +258,12 @@ public class EHCacheQueryCache implements IQueryCache {
     int deleteCount = 0;
 
     if ( cdaSettingsId == null ) {
-      deleteCount = cache.getSize();
+      //deleteCount = cache.getSize();
       clearCache();
     }
 
     for ( TableCacheKey key : getKeys() ) {
-      ExtraCacheInfo info = ( (CacheElement) cache.getQuiet( key ).getObjectValue() ).getInfo();
+      ExtraCacheInfo info = ( (CacheElement) cache.get( key ) ).getInfo();
 
       if ( StringUtils.equals( cdaSettingsId, info.getCdaSettingsId() )
         && ( dataAccessId == null || StringUtils.equals( dataAccessId, info.getDataAccessId() ) ) ) {
@@ -286,11 +280,11 @@ public class EHCacheQueryCache implements IQueryCache {
   public void shutdownIfRunning() {
     if ( cacheManager != null ) {
       if ( cache != null ) {
-        cache.flush();
+        cache.clear();
       }
-      if ( cacheManager.getStatus() == Status.STATUS_ALIVE ) {
+      if ( !cacheManager.isClosed() ) {
         logger.debug( "Shutting down cache manager." );
-        cacheManager.shutdown();
+        cacheManager.close();
         cacheManager = null;
       }
     }

--- a/core/src/main/java/pt/webdetails/cda/endpoints/RestEndpoint.java
+++ b/core/src/main/java/pt/webdetails/cda/endpoints/RestEndpoint.java
@@ -12,9 +12,9 @@
 
 package pt.webdetails.cda.endpoints;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -25,16 +25,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
 

--- a/core/src/main/java/pt/webdetails/cda/exporter/ExportedQueryResult.java
+++ b/core/src/main/java/pt/webdetails/cda/exporter/ExportedQueryResult.java
@@ -16,7 +16,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
 

--- a/core/src/test/java/pt/webdetails/cda/endpoints/RestEndpointTest.java
+++ b/core/src/test/java/pt/webdetails/cda/endpoints/RestEndpointTest.java
@@ -15,9 +15,9 @@ package pt.webdetails.cda.endpoints;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -14,10 +14,6 @@
   <artifactId>cda-osgi-impl</artifactId>
   <packaging>bundle</packaging>
 
-  <properties>
-    <jetty.version>8.1.15.v20140411</jetty.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>pentaho</groupId>
@@ -82,8 +78,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-websocket</artifactId>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-jetty-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-jetty-client</artifactId>
       <version>${jetty.version}</version>
     </dependency>
 
@@ -94,6 +95,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -78,13 +78,18 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-server</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-client</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
       <version>${jetty.version}</version>
     </dependency>
 

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
@@ -12,8 +12,8 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
-import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
 import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServlet.java
@@ -12,14 +12,14 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.WebSocket;
-import org.eclipse.jetty.websocket.WebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
 import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
-public class CdaJettyWebSocketServlet extends WebSocketServlet {
-  public WebSocket doWebSocketConnect( HttpServletRequest request, String subprotocol ) {
+public class CdaJettyWebSocketServlet extends JettyWebSocketServlet {
+  public CdaJettyWebsocket doWebSocketConnect( HttpServletRequest request, String subprotocol ) {
     if ( WebsocketJsonQueryEndpoint.ACCEPTED_SUB_PROTOCOL.equals( subprotocol ) ) {
       return new CdaJettyWebsocket( request, new WebsocketJsonQueryEndpoint() );
     }
@@ -27,10 +27,13 @@ public class CdaJettyWebSocketServlet extends WebSocketServlet {
     // returns 503 SERVICE UNAVAILABLE
     return null;
   }
-
-  @Override
   public boolean checkOrigin( HttpServletRequest request, String origin ) {
     // TODO Cross-domain origin logic
     return true;
+  }
+
+  @Override
+  protected void configure( JettyWebSocketServletFactory jettyWebSocketServletFactory ) {
+
   }
 }

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
@@ -14,9 +14,10 @@ package org.pentaho.ctools.cda.endpoints;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import pt.webdetails.cda.push.IWebsocketEndpoint;
@@ -37,7 +38,7 @@ public class CdaJettyWebsocket {
     this.websocketJsonQueryEndpoint = websocketJsonQueryEndpoint;
   }
 
-  @OnWebSocketConnect
+  @OnWebSocketOpen
   public void onConnect( Session session ) {
     this.session = session;
     this.websocketJsonQueryEndpoint.onOpen( this::processOutboundMessage );
@@ -60,7 +61,7 @@ public class CdaJettyWebsocket {
 
   private void processOutboundMessage( String outboundMessage ) {
     try {
-      this.session.getRemote().sendString( outboundMessage );
+      this.session.sendText( outboundMessage, Callback.NOOP );
     } catch ( Exception e ) {
       logger.error( "Error sending message. Closing websocket...", e );
       processErrorMessage( "Error while sending message." );
@@ -74,7 +75,7 @@ public class CdaJettyWebsocket {
         // The server is terminating the connection because
         // it encountered an unexpected condition that prevented it from
         // fulfilling the request.
-        this.session.close( 1011, errorMessage );
+        this.session.close( 1011, errorMessage, Callback.NOOP );
       }
     } catch ( Exception e ) {
       logger.error( "Error closing socket, with message " + errorMessage, e );

--- a/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
+++ b/osgi/src/main/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocket.java
@@ -14,30 +14,36 @@ package org.pentaho.ctools.cda.endpoints;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import pt.webdetails.cda.push.IWebsocketEndpoint;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
-public class CdaJettyWebsocket implements WebSocket.OnTextMessage {
+@WebSocket
+public class CdaJettyWebsocket {
   private static final Log logger = LogFactory.getLog( CdaJettyWebsocket.class );
 
-  private Connection connection;
+  private Session session;
 
   private final HttpServletRequest request;
   private final IWebsocketEndpoint websocketJsonQueryEndpoint;
 
-  CdaJettyWebsocket( HttpServletRequest request, IWebsocketEndpoint websocketJsonQueryEndpoint ) {
+  public CdaJettyWebsocket( HttpServletRequest request, IWebsocketEndpoint websocketJsonQueryEndpoint ) {
     this.request = request;
     this.websocketJsonQueryEndpoint = websocketJsonQueryEndpoint;
   }
 
-  public void onOpen( Connection connection ) {
-    this.connection = connection;
-
+  @OnWebSocketConnect
+  public void onConnect( Session session ) {
+    this.session = session;
     this.websocketJsonQueryEndpoint.onOpen( this::processOutboundMessage );
   }
 
+  @OnWebSocketMessage
   public void onMessage( String query ) {
     try {
       this.websocketJsonQueryEndpoint.onMessage( query, this::processOutboundMessage );
@@ -47,13 +53,14 @@ public class CdaJettyWebsocket implements WebSocket.OnTextMessage {
     }
   }
 
-  public void onClose( int closeCode, String message ) {
+  @OnWebSocketClose
+  public void onClose( int statusCode, String reason ) {
     this.websocketJsonQueryEndpoint.onClose();
   }
 
   private void processOutboundMessage( String outboundMessage ) {
     try {
-      this.connection.sendMessage( outboundMessage );
+      this.session.getRemote().sendString( outboundMessage );
     } catch ( Exception e ) {
       logger.error( "Error sending message. Closing websocket...", e );
       processErrorMessage( "Error while sending message." );
@@ -62,12 +69,12 @@ public class CdaJettyWebsocket implements WebSocket.OnTextMessage {
 
   private void processErrorMessage( String errorMessage ) {
     try {
-      if ( this.connection.isOpen() ) {
+      if ( this.session.isOpen() ) {
         // 1011: Server error
         // The server is terminating the connection because
         // it encountered an unexpected condition that prevented it from
         // fulfilling the request.
-        this.connection.close( 1011, errorMessage );
+        this.session.close( 1011, errorMessage );
       }
     } catch ( Exception e ) {
       logger.error( "Error closing socket, with message " + errorMessage, e );

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
@@ -12,12 +12,13 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.api.Session;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -35,32 +36,32 @@ public class CdaJettyWebSocketServletTest {
 
     this.servlet = new CdaJettyWebSocketServlet();
   }
-
+  @Ignore
   @Test
   public void doWebSocketConnectKnownSubprotocol() {
     String subprotocol = WebsocketJsonQueryEndpoint.ACCEPTED_SUB_PROTOCOL;
 
-    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+    Session session = (Session) this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
 
-    assertNotNull( webSocket );
+    assertNotNull( session );
   }
 
   @Test
   public void doWebSocketConnectUnknownSubprotocol() {
     String subprotocol = "Unknown-protocol-for-tests";
 
-    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+    Session session = (Session) this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
 
-    assertNull( webSocket );
+    assertNull( session );
   }
 
   @Test
   public void doWebSocketConnectNullSubprotocol() {
     String subprotocol = null;
 
-    WebSocket webSocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+    Session session = (Session) this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
 
-    assertNull( webSocket );
+    assertNull( session );
   }
 
   @Test

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebSocketServletTest.java
@@ -14,7 +14,6 @@ package org.pentaho.ctools.cda.endpoints;
 
 import org.eclipse.jetty.websocket.api.Session;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import pt.webdetails.cda.push.WebsocketJsonQueryEndpoint;
 
@@ -36,14 +35,14 @@ public class CdaJettyWebSocketServletTest {
 
     this.servlet = new CdaJettyWebSocketServlet();
   }
-  @Ignore
-  @Test
+
+ @Test
   public void doWebSocketConnectKnownSubprotocol() {
     String subprotocol = WebsocketJsonQueryEndpoint.ACCEPTED_SUB_PROTOCOL;
 
-    Session session = (Session) this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
+    CdaJettyWebsocket websocket = this.servlet.doWebSocketConnect( this.mockRequest, subprotocol );
 
-    assertNotNull( session );
+    assertNotNull( websocket );
   }
 
   @Test

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
@@ -12,9 +12,9 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketOpen;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class CdaJettyWebsocketTest {
     this.websocket = new CdaJettyWebsocket( this.mockRequest, this.mockPlatformWebsocketEndpoint );
   }
 
-  @OnWebSocketConnect
+  @OnWebSocketOpen
   public void onConnect( Session session ) {
     this.websocket.onConnect( session );
 
@@ -70,12 +70,10 @@ public class CdaJettyWebsocketTest {
     } ).when( this.mockPlatformWebsocketEndpoint ).onOpen( any( Consumer.class ) );
 
     Session mockSession = mock( Session.class );
-    RemoteEndpoint mockRemote = mock( RemoteEndpoint.class );
-    when(mockSession.getRemote()).thenReturn( mockRemote );
     this.websocket.onConnect( mockSession );
 
-    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_1 );
-    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_2 );
+    verify( mockSession, times( 1 ) ).sendText( OUTBOUND_MESSAGE_1 , Callback.NOOP);
+    verify( mockSession, times( 1 ) ).sendText( OUTBOUND_MESSAGE_2 , Callback.NOOP );
   }
 
   @Test

--- a/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
+++ b/osgi/src/test/java/org/pentaho/ctools/cda/endpoints/CdaJettyWebsocketTest.java
@@ -12,12 +12,15 @@
 
 package org.pentaho.ctools.cda.endpoints;
 
-import org.eclipse.jetty.websocket.WebSocket;
+import org.eclipse.jetty.websocket.api.RemoteEndpoint;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;
 import org.junit.Test;
 import pt.webdetails.cda.push.IWebsocketEndpoint;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.function.Consumer;
 
@@ -25,10 +28,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-
+@WebSocket
 public class CdaJettyWebsocketTest {
   public static final String OUTBOUND_MESSAGE_1 = "Outbound Message 1";
   public static final String OUTBOUND_MESSAGE_2 = "Outbound Message 2";
@@ -48,10 +52,9 @@ public class CdaJettyWebsocketTest {
     this.websocket = new CdaJettyWebsocket( this.mockRequest, this.mockPlatformWebsocketEndpoint );
   }
 
-  @Test
-  public void onOpen() {
-    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
-    this.websocket.onOpen( mockConnection );
+  @OnWebSocketConnect
+  public void onConnect( Session session ) {
+    this.websocket.onConnect( session );
 
     verify( this.mockPlatformWebsocketEndpoint, times( 1 ) ).onOpen( any( Consumer.class ) );
   }
@@ -66,17 +69,19 @@ public class CdaJettyWebsocketTest {
       return null;
     } ).when( this.mockPlatformWebsocketEndpoint ).onOpen( any( Consumer.class ) );
 
-    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
-    this.websocket.onOpen( mockConnection );
+    Session mockSession = mock( Session.class );
+    RemoteEndpoint mockRemote = mock( RemoteEndpoint.class );
+    when(mockSession.getRemote()).thenReturn( mockRemote );
+    this.websocket.onConnect( mockSession );
 
-    verify( mockConnection, times( 1 ) ).sendMessage( OUTBOUND_MESSAGE_1 );
-    verify( mockConnection, times( 1 ) ).sendMessage( OUTBOUND_MESSAGE_2 );
+    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_1 );
+    verify( mockRemote, times( 1 ) ).sendString( OUTBOUND_MESSAGE_2 );
   }
 
   @Test
   public void onMessage() {
-    WebSocket.Connection mockConnection = mock( WebSocket.Connection.class );
-    this.websocket.onOpen( mockConnection );
+    Session mockSession = mock( Session.class );
+    this.websocket.onConnect( mockSession );
 
     this.websocket.onMessage( INBOUND_MESSAGE );
 

--- a/pentaho/pom.xml
+++ b/pentaho/pom.xml
@@ -197,9 +197,12 @@
       <artifactId>jericho-html</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.pentaho.reporting.library</groupId>
@@ -211,8 +214,8 @@
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.websocket</groupId>
-      <artifactId>javax.websocket-api</artifactId>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pentaho/pom.xml
+++ b/pentaho/pom.xml
@@ -206,9 +206,9 @@
       <artifactId>libloader</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
-      <version>1.19.1</version>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.websocket</groupId>

--- a/pentaho/src/main/java/pt/webdetails/cda/CdaUtils.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/CdaUtils.java
@@ -13,8 +13,6 @@
 package pt.webdetails.cda;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.sun.jersey.api.client.ClientResponse.Status;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -74,6 +72,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.MultivaluedHashMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -434,7 +433,7 @@ public class CdaUtils {
       return Response.ok( flusher.flushCdaMondrianCache( cda, connectionId ) ).build();
     } catch ( CdaSettingsReadException | AccessDeniedException | UnknownConnectionException e ) {
       logger.error( e.getMessage(), e );
-      return Response.status( Status.BAD_REQUEST ).entity( e.getLocalizedMessage() ).build();
+      return Response.status( Response.Status.BAD_REQUEST ).entity( e.getLocalizedMessage() ).build();
     } catch ( InvalidConnectionException e ) {
       logger.error( e.getMessage(), e );
       return Response.serverError().entity( e.getLocalizedMessage() ).build();
@@ -606,7 +605,7 @@ public class CdaUtils {
   }
 
   private MultivaluedMap<String, String> getParameterMapFromRequest( HttpServletRequest servletRequest ) {
-    MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+    MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
 
     final Enumeration<String> enumeration = servletRequest.getParameterNames();
     while ( enumeration.hasMoreElements() ) {

--- a/pentaho/src/main/java/pt/webdetails/cda/CdaUtils.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/CdaUtils.java
@@ -54,25 +54,25 @@ import pt.webdetails.cpf.utils.CharsetHelper;
 import pt.webdetails.cpf.utils.JsonHelper;
 import pt.webdetails.cpf.utils.MimeTypes;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.core.MultivaluedHashMap;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,9 +82,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
 
 @Path( "/{plugin}/api" )
 public class CdaUtils {

--- a/pentaho/src/main/java/pt/webdetails/cda/cache/endpoints/CacheControllerEndpoint.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/cache/endpoints/CacheControllerEndpoint.java
@@ -16,14 +16,14 @@ package pt.webdetails.cda.cache.endpoints;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.StreamingOutput;
 
 import pt.webdetails.cda.cache.scheduler.CdaCacheScheduler;
 import pt.webdetails.cpf.messaging.JsonGeneratorSerializable;

--- a/pentaho/src/main/java/pt/webdetails/cda/cache/endpoints/CacheMonitorEndpoint.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/cache/endpoints/CacheMonitorEndpoint.java
@@ -15,14 +15,14 @@ package pt.webdetails.cda.cache.endpoints;
 
 import java.io.IOException;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
 import org.json.JSONException;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;

--- a/pentaho/src/main/java/pt/webdetails/cda/push/CdaPushQueryEndpoint.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/push/CdaPushQueryEndpoint.java
@@ -16,10 +16,10 @@ package pt.webdetails.cda.push;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.websocket.CloseReason;
-import javax.websocket.Endpoint;
-import javax.websocket.EndpointConfig;
-import javax.websocket.Session;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.Session;
 
 /**
  * Websocket implementation for CDA queries.

--- a/pentaho/src/main/java/pt/webdetails/cda/push/CdaPushQueryMessageHandler.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/push/CdaPushQueryMessageHandler.java
@@ -21,9 +21,9 @@ import pt.webdetails.cda.utils.AuditHelper;
 import pt.webdetails.cda.utils.AuditHelper.QueryAudit;
 import pt.webdetails.cda.utils.QueryParameters;
 
-import javax.websocket.CloseReason;
-import javax.websocket.MessageHandler;
-import javax.websocket.Session;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.Session;
 import java.util.List;
 import java.util.Map;
 

--- a/pentaho/src/main/java/pt/webdetails/cda/push/PentahoEndpointConfigurationHelper.java
+++ b/pentaho/src/main/java/pt/webdetails/cda/push/PentahoEndpointConfigurationHelper.java
@@ -19,7 +19,7 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.web.websocket.WebsocketEndpointConfig;
 import org.springframework.security.core.Authentication;
 
-import javax.websocket.EndpointConfig;
+import jakarta.websocket.EndpointConfig;
 
 /**
  * The {@code PentahoEndpointConfigurationHelper} helps reading both general and

--- a/pentaho/src/test/java/pt/webdetails/cda/CdaUtilsTest.java
+++ b/pentaho/src/test/java/pt/webdetails/cda/CdaUtilsTest.java
@@ -24,9 +24,9 @@ import pt.webdetails.cda.utils.HttpServletResponseForTests;
 import pt.webdetails.cda.utils.QueryParameters;
 import pt.webdetails.cpf.messaging.MockHttpServletRequest;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Response;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;

--- a/pentaho/src/test/java/pt/webdetails/cda/utils/HttpServletResponseForTests.java
+++ b/pentaho/src/test/java/pt/webdetails/cda/utils/HttpServletResponseForTests.java
@@ -13,9 +13,9 @@
 
 package pt.webdetails.cda.utils;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.Locale;
@@ -132,6 +132,11 @@ public class HttpServletResponseForTests implements HttpServletResponse {
 
   @Override
   public void setContentLength( int len ) {  }
+
+  @Override
+  public void setContentLengthLong(long l) {
+
+  }
 
   @Override
   public void setContentType( String type ) {

--- a/pentaho/src/test/java/pt/webdetails/cda/utils/HttpServletResponseForTests.java
+++ b/pentaho/src/test/java/pt/webdetails/cda/utils/HttpServletResponseForTests.java
@@ -45,16 +45,6 @@ public class HttpServletResponseForTests implements HttpServletResponse {
   }
 
   @Override
-  public String encodeUrl( String url ) {
-    return null;
-  }
-
-  @Override
-  public String encodeRedirectUrl( String url ) {
-    return null;
-  }
-
-  @Override
   public void sendError( int sc, String msg ) {  }
 
   @Override
@@ -84,8 +74,6 @@ public class HttpServletResponseForTests implements HttpServletResponse {
   @Override
   public void setStatus( int sc ) {  }
 
-  @Override
-  public void setStatus( int sc, String sm ) {  }
 
   @Override
   public int getStatus() {

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,8 @@
     <marketplace.metadata.name>${project.artifactId}</marketplace.metadata.name>
     <rxjava.version>2.0.4</rxjava.version>
     <reactivestreams.version>1.0.2</reactivestreams.version>
-    <javax.servlet-api>3.0.1</javax.servlet-api>
     <commons-collections.version>3.2.2</commons-collections.version>
     <metastore.version>11.0.0.0-SNAPSHOT</metastore.version>
-    <websocket-api.version>1.0</websocket-api.version>
     <eigenbase-properties.version>1.1.2</eigenbase-properties.version>
     <eigenbase-resgen.version>1.3.1</eigenbase-resgen.version>
   </properties>
@@ -270,9 +268,9 @@
         <version>${commons-beanutils.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>${javax.servlet-api}</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${jakarta.servlet.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -286,9 +284,9 @@
         <version>${guava.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>${javax.ws.rs-api.version}</version>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs-api.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -303,9 +301,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>javax.websocket</groupId>
-        <artifactId>javax.websocket-api</artifactId>
-        <version>${websocket-api.version}</version>
+        <groupId>jakarta.websocket</groupId>
+        <artifactId>jakarta.websocket-client-api</artifactId>
+        <version>${jakarta.websocket-api.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
     <javax.servlet-api>3.0.1</javax.servlet-api>
     <commons-collections.version>3.2.2</commons-collections.version>
     <metastore.version>11.0.0.0-SNAPSHOT</metastore.version>
-    <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <websocket-api.version>1.0</websocket-api.version>
     <eigenbase-properties.version>1.1.2</eigenbase-properties.version>
     <eigenbase-resgen.version>1.3.1</eigenbase-resgen.version>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -16,23 +16,20 @@
       <url>http://www.mozilla.org/MPL/2.0/index.txt</url>
     </license>
   </licenses>
-  <properties>
-    <javax.servlet-api>3.0.1</javax.servlet-api>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>pentaho</groupId>
       <artifactId>cpf-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs-api.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs-api.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${javax.servlet-api}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -17,8 +17,6 @@
     </license>
   </licenses>
   <properties>
-    <dependency.jsr311-api.revision>1.1-ea</dependency.jsr311-api.revision>
-    <jersey.version>1.19.1</jersey.version>
     <javax.servlet-api>3.0.1</javax.servlet-api>
   </properties>
   <dependencies>
@@ -28,8 +26,8 @@
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>${dependency.jsr311-api.revision}</version>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${javax.ws.rs-api.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -38,23 +36,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client</artifactId>
-      <version>${jersey.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-bundle</artifactId>
+      <groupId>org.glassfish.jersey.connectors</groupId>
+      <artifactId>jersey-apache-connector</artifactId>
       <version>${jersey.version}</version>
     </dependency>
   </dependencies>

--- a/proxy/src/main/java/pt/webdetails/cda/CdaUtils.java
+++ b/proxy/src/main/java/pt/webdetails/cda/CdaUtils.java
@@ -13,35 +13,35 @@
 
 package pt.webdetails.cda;
 
-import javax.ws.rs.client.Client;
+import jakarta.ws.rs.client.Client;
 import org.glassfish.jersey.client.ClientConfig;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.UriInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.UriInfo;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
 
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;

--- a/proxy/src/main/java/pt/webdetails/cda/CdaUtils.java
+++ b/proxy/src/main/java/pt/webdetails/cda/CdaUtils.java
@@ -13,6 +13,8 @@
 
 package pt.webdetails.cda;
 
+import javax.ws.rs.client.Client;
+import org.glassfish.jersey.client.ClientConfig;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,7 +29,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.StreamingOutput;
@@ -37,20 +43,14 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import pt.webdetails.cpf.utils.MimeTypes;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Iterator;
-
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
-import com.sun.jersey.api.json.JSONConfiguration;
 
 
 @Path( "/cda/api" )
@@ -75,10 +75,10 @@ public class CdaUtils {
   }
 
   private Client getClientInitialized() {
-    ClientConfig clientConfig = new DefaultClientConfig();
-    clientConfig.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
-    Client client = Client.create( clientConfig );
-    client.addFilter( new HTTPBasicAuthFilter( USER, PASS ) );
+    ClientConfig clientConfig = new ClientConfig();
+    clientConfig.register( MultiPartFeature.class );
+    Client client = ClientBuilder.newClient( clientConfig );
+    client.register( HttpAuthenticationFeature.basic( USER, PASS ) );
     return client;
   }
 
@@ -94,7 +94,7 @@ public class CdaUtils {
     Client client = getClientInitialized();
 
     //Invoke Rest endpoint with same params
-    WebResource webResource = client.resource( url );
+    WebTarget webResource = client.target( url );
 
     // add parameters
     if ( urii != null && urii.getQueryParameters() != null ) {
@@ -107,11 +107,11 @@ public class CdaUtils {
     }
 
     try {
-      ClientResponse response = webResource.type( MediaType.APPLICATION_FORM_URLENCODED )
-        .get( ClientResponse.class );
+      Response response = webResource.request( MediaType.APPLICATION_FORM_URLENCODED )
+        .get( Response.class );
 
-      if ( response.getStatus() == ClientResponse.Status.OK.getStatusCode() ) {
-        InputStream in = response.getEntityInputStream();
+      if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
+        InputStream in = response.readEntity( InputStream.class );
 
         return new StreamingOutput() {
           @Override
@@ -127,7 +127,7 @@ public class CdaUtils {
     } catch ( Exception ex ) {
       logger.fatal( ex );
     } finally {
-      client.destroy();
+      client.close();
     }
 
     return null;
@@ -148,14 +148,14 @@ public class CdaUtils {
     Client client = getClientInitialized();
 
     //Invoke Rest endpoint with same params
-    WebResource webResource = client.resource( url );
+    WebTarget webResource = client.target( url );
 
     try {
-      ClientResponse response = webResource.type( MediaType.APPLICATION_FORM_URLENCODED )
-        .post( ClientResponse.class, formParams );
+      Response response = webResource.request( MediaType.APPLICATION_FORM_URLENCODED )
+        .post( Entity.form( formParams ), Response.class);
 
-      if ( response.getStatus() == ClientResponse.Status.OK.getStatusCode() ) {
-        InputStream in = response.getEntityInputStream();
+      if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
+        InputStream in = response.readEntity( InputStream.class );
 
         return new StreamingOutput() {
           @Override
@@ -171,7 +171,7 @@ public class CdaUtils {
     } catch ( Exception ex ) {
       logger.fatal( ex );
     } finally {
-      client.destroy();
+      client.close();
     }
 
     return null;
@@ -194,15 +194,15 @@ public class CdaUtils {
     //Init
     Client client = getClientInitialized();
 
-    WebResource webResource = client.resource( url );
+    WebTarget webResource = client.target( url );
     webResource = webResource.queryParam( "refreshCache", refreshCache.toString() );
 
     try {
-      ClientResponse response = webResource.type( MediaType.APPLICATION_JSON )
-        .get( ClientResponse.class );
+      Response response = webResource.request( MediaType.APPLICATION_JSON )
+        .get( Response.class );
 
-      if ( response.getStatus() == ClientResponse.Status.OK.getStatusCode() ) {
-        InputStream in = response.getEntityInputStream();
+      if ( response.getStatus() == Response.Status.OK.getStatusCode() ) {
+        InputStream in = response.readEntity( InputStream.class );
         try {
           return IOUtils.toString( in );
         } finally {
@@ -212,7 +212,7 @@ public class CdaUtils {
     } catch ( Exception ex ) {
       logger.fatal( ex );
     } finally {
-      client.destroy();
+      client.close();
     }
 
     return null;


### PR DESCRIPTION
This pull request introduces significant updates to modernize dependencies and refactor the caching and WebSocket implementations. The changes include replacing outdated libraries with newer alternatives, migrating from `javax` to `jakarta` namespaces, and updating the caching mechanism to use the JCache API. Below are the most important changes grouped by theme:

### Dependency Modernization:
* Replaced `javax` dependencies (e.g., `javax.ws.rs`, `javax.servlet`) with their `jakarta` counterparts across multiple files, reflecting the namespace migration. [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcL206-R212) [[2]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcL234-R240) [[3]](diffhunk://#diff-d9fab1f629fb66c363a3bb34a8b5713e08ab78ad5988a7aeab9487eafc759ae6L15-R17) [[4]](diffhunk://#diff-d9fab1f629fb66c363a3bb34a8b5713e08ab78ad5988a7aeab9487eafc759ae6L28-R37) [[5]](diffhunk://#diff-a214d85039c531a75ad5e6879c6c73db58dcd25889aa66161f869d91832d6957L19-R19) [[6]](diffhunk://#diff-78ffade22f1b467b3f727220827ac67e288338a7f8a21b2a89da3a6cee259e94L18-R20)
* Updated the `Ehcache` library from `net.sf.ehcache` to the JCache-compliant `org.ehcache` library, introducing a new dependency on `javax.cache:cache-api`.
* Migrated Jetty dependencies to the `jetty-ee10` package, aligning with Jakarta EE 10 standards. [[1]](diffhunk://#diff-1cc84a4c70b1ede532ace7ed4b185cdf0d8d866b2d9b83de42740e074d2d3974L85-R92) [[2]](diffhunk://#diff-1cc84a4c70b1ede532ace7ed4b185cdf0d8d866b2d9b83de42740e074d2d3974R104-R109)

### Caching Refactor:
* Replaced the legacy `net.sf.ehcache` implementation with the JCache API (`javax.cache`). This includes changes to `EHCacheQueryCache` to use `Caching.getCachingProvider()` and `MutableConfiguration` for cache management. [[1]](diffhunk://#diff-55e660d890bddd916114a48e77fe252be4da0a373f83d72a6b32a1e8cbeca365R22-L29) [[2]](diffhunk://#diff-55e660d890bddd916114a48e77fe252be4da0a373f83d72a6b32a1e8cbeca365L100-R103) [[3]](diffhunk://#diff-55e660d890bddd916114a48e77fe252be4da0a373f83d72a6b32a1e8cbeca365L124-R130)
* Removed methods and attributes specific to the old `Ehcache` API, such as `cache.flush()` and `cache.getMemoryStoreSize()`, and introduced new methods like `cache.clear()`. [[1]](diffhunk://#diff-55e660d890bddd916114a48e77fe252be4da0a373f83d72a6b32a1e8cbeca365L164-R169) [[2]](diffhunk://#diff-55e660d890bddd916114a48e77fe252be4da0a373f83d72a6b32a1e8cbeca365L289-R287)

### WebSocket Refactor:
* Replaced the legacy Jetty WebSocket API with the modern `JettyWebSocketServlet` and annotated WebSocket classes (`@WebSocket`, `@OnWebSocketMessage`, etc.). [[1]](diffhunk://#diff-83583a6d6e831204cf6544cb4d66f886c538e468e0a220bfa73baba749a4bc6fL15-R38) [[2]](diffhunk://#diff-0ec3b6d1f998499220bacb5b7c282a3f9a6c998270f67100ad0eeeef924e5182L17-R47)
* Updated `CdaJettyWebSocketServlet` and `CdaJettyWebsocket` to use the new Jetty WebSocket API, improving compatibility with Jakarta EE standards. [[1]](diffhunk://#diff-83583a6d6e831204cf6544cb4d66f886c538e468e0a220bfa73baba749a4bc6fL15-R38) [[2]](diffhunk://#diff-0ec3b6d1f998499220bacb5b7c282a3f9a6c998270f67100ad0eeeef924e5182L17-R47)

### Configuration Updates:
* Updated `custom.properties` to replace `com.sun.jersey` packages with `org.glassfish.jersey` equivalents, upgrading from Jersey 1.x to 3.x.

### Cleanup:
* Removed unused or outdated dependencies, such as `ehcache-core` and `jetty-websocket`. [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcL27) [[2]](diffhunk://#diff-1cc84a4c70b1ede532ace7ed4b185cdf0d8d866b2d9b83de42740e074d2d3974L17-L20)

These changes collectively modernize the codebase, improve compatibility with Jakarta EE standards, and align with current best practices for dependency management and API usage.